### PR TITLE
fix: tablefull errors when running benchmark, clearing storage

### DIFF
--- a/benchmark.zig
+++ b/benchmark.zig
@@ -14,7 +14,7 @@ pub fn main() !void {
     // Database's arena allocator for static allocation
     var database_arena = std.heap.ArenaAllocator.init(page_allocator);
     defer database_arena.deinit();
-    
+
     // Create static allocator for database
     var static_alloc = static_allocator.StaticAllocator.init(database_arena.allocator());
 
@@ -23,14 +23,14 @@ pub fn main() !void {
     // Detect cache topology first to get actual L3 cache size
     const cache_topology = @import("src/cache_topology.zig");
     const topology = try cache_topology.analyzeCacheTopology(static_alloc.allocator());
-    
+
     // Calculate detected L3 cache size
     var total_l3_cache_kb: u64 = 0;
     for (topology.l3_domains) |domain| {
         total_l3_cache_kb += domain.cache_size_kb;
     }
     const detected_cache_mb = @as(u32, @intCast(total_l3_cache_kb / 1024));
-    
+
     // Calculate target capacity based on actual cache size and record size
     const cache_line_size = topology.cache_line_size;
     const record_size = cache_line_size; // Each record fits in one cache line
@@ -43,26 +43,34 @@ pub fn main() !void {
     };
 
     var database = try wild.WILD.init(static_alloc.allocator(), config);
-    
+
     // Transition to static state - no more database allocations allowed
     static_alloc.transitionToStatic();
 
     // Get actual database capacity for benchmark sizing
     const db_stats = database.getStats();
     const safe_capacity = @as(u32, @intFromFloat(@as(f64, @floatFromInt(db_stats.total_capacity)) * 0.6)); // Use 60% of capacity for testing
-    
-    std.debug.print("Database: {} MB cache, {} records\n", .{detected_cache_mb, db_stats.total_capacity});
+
+    std.debug.print("Database: {} MB cache, {} records\n", .{ detected_cache_mb, db_stats.total_capacity });
 
     // Run benchmark suite using benchmark allocator with safe capacity
     try runSingleOperationBenchmarks(&database, benchmark_allocator, safe_capacity);
-    
-    
+
+    // Clear database between benchmarks to ensure clean state
+    database.clear();
+    std.debug.print("Database cleared between benchmarks\n", .{});
+
     try runBatchOperationBenchmarks(&database, benchmark_allocator, safe_capacity);
+
+    // Clear database between benchmarks to ensure clean state
+    database.clear();
+    std.debug.print("Database cleared between benchmarks\n", .{});
+
     try runMixedWorkloadBenchmark(&database, benchmark_allocator, safe_capacity);
 
     // Final hardware report
     database.printHardwareReport();
-    
+
     // Cleanup in correct order: database first, then static allocator
     static_alloc.transitionToDeinit();
     database.deinit();
@@ -72,10 +80,10 @@ pub fn main() !void {
 fn runSingleOperationBenchmarks(database: *wild.WILD, allocator: std.mem.Allocator, max_records: u32) !void {
     std.debug.print("\nSingle Operations\n", .{});
 
-    const num_operations = @max(10_000, @min(max_records, 100_000));  // At least 10K, up to safe capacity or 100K
+    // Use half of max_records for each phase to stay within capacity
+    const num_operations = max_records / 2;
     var keys = try allocator.alloc(u64, num_operations);
     defer allocator.free(keys);
-
 
     // Prepare test data
     for (0..num_operations) |i| {
@@ -88,12 +96,11 @@ fn runSingleOperationBenchmarks(database: *wild.WILD, allocator: std.mem.Allocat
         try database.write(keys[i], test_data);
     }
 
-
     std.debug.print("Write test: ", .{});
     const write_start = std.time.nanoTimestamp();
 
     for (keys, 0..) |_, i| {
-        const key = @as(u64, num_operations + 1 + i); // Use different key space: 5001-10000
+        const key = @as(u64, num_operations + 1 + i);
         const test_data = try std.fmt.allocPrint(allocator, "write_test_{}", .{key});
         defer allocator.free(test_data);
         try database.write(key, test_data);
@@ -103,9 +110,7 @@ fn runSingleOperationBenchmarks(database: *wild.WILD, allocator: std.mem.Allocat
     const write_duration = @as(f64, @floatFromInt(write_end - write_start)) / 1_000_000_000.0;
     const write_ops_per_sec = @as(f64, @floatFromInt(num_operations)) / write_duration;
 
-    std.debug.print("{} ops in {d:.3}s = {d:.0} ops/sec\n", .{
-        num_operations, write_duration, write_ops_per_sec
-    });
+    std.debug.print("{} ops in {d:.3}s = {d:.0} ops/sec\n", .{ num_operations, write_duration, write_ops_per_sec });
 
     std.debug.print("Read test:  ", .{});
     const read_start = std.time.nanoTimestamp();
@@ -120,34 +125,31 @@ fn runSingleOperationBenchmarks(database: *wild.WILD, allocator: std.mem.Allocat
     const read_duration = @as(f64, @floatFromInt(read_end - read_start)) / 1_000_000_000.0;
     const read_ops_per_sec = @as(f64, @floatFromInt(num_operations)) / read_duration;
 
-    std.debug.print("{} ops in {d:.3}s = {d:.0} ops/sec ({} found)\n", .{
-        num_operations, read_duration, read_ops_per_sec, successful_reads
-    });
+    std.debug.print("{} ops in {d:.3}s = {d:.0} ops/sec ({} found)\n", .{ num_operations, read_duration, read_ops_per_sec, successful_reads });
 
     // Latency measurements
     const avg_write_latency = (write_duration * 1_000_000_000.0) / @as(f64, @floatFromInt(num_operations));
     const avg_read_latency = (read_duration * 1_000_000_000.0) / @as(f64, @floatFromInt(num_operations));
 
-    std.debug.print("Latency - Write: {d:.0}ns, Read: {d:.0}ns\n", .{avg_write_latency, avg_read_latency});
+    std.debug.print("Latency - Write: {d:.0}ns, Read: {d:.0}ns\n", .{ avg_write_latency, avg_read_latency });
 
     // Compare to Redis typical performance (rough estimates)
     const redis_write_latency_ns = 50_000; // ~50μs for Redis
-    const redis_read_latency_ns = 25_000;  // ~25μs for Redis
+    const redis_read_latency_ns = 25_000; // ~25μs for Redis
 
     const write_speedup = @as(f64, @floatFromInt(redis_write_latency_ns)) / avg_write_latency;
     const read_speedup = @as(f64, @floatFromInt(redis_read_latency_ns)) / avg_read_latency;
 
-    std.debug.print("vs Redis: {d:.1}x write, {d:.1}x read\n", .{write_speedup, read_speedup});
+    std.debug.print("vs Redis: {d:.1}x write, {d:.1}x read\n", .{ write_speedup, read_speedup });
 }
 
 fn runBatchOperationBenchmarks(database: *wild.WILD, allocator: std.mem.Allocator, max_records: u32) !void {
     std.debug.print("\nBatch Operations\n", .{});
 
     const optimal_batch_size = database.getOptimalBatchSize();
-    const max_batches = @max(1, max_records / optimal_batch_size);  // Calculate based on safe capacity
-    const num_batches = @min(max_batches, 1_000);  // Increase to 1,000 batches
+    const max_batches = @max(1, max_records / optimal_batch_size); // Calculate based on safe capacity
+    const num_batches = max_batches; // Use max_batches directly to respect safe_capacity
     const total_operations = optimal_batch_size * num_batches;
-
 
     var batch_keys = try allocator.alloc(u64, optimal_batch_size);
     defer allocator.free(batch_keys);
@@ -175,9 +177,7 @@ fn runBatchOperationBenchmarks(database: *wild.WILD, allocator: std.mem.Allocato
     const batch_write_duration = @as(f64, @floatFromInt(batch_write_end - batch_write_start)) / 1_000_000_000.0;
     const batch_write_ops_per_sec = @as(f64, @floatFromInt(total_operations)) / batch_write_duration;
 
-    std.debug.print("{} ops in {d:.3}s = {d:.0} ops/sec\n", .{
-        total_operations, batch_write_duration, batch_write_ops_per_sec
-    });
+    std.debug.print("{} ops in {d:.3}s = {d:.0} ops/sec\n", .{ total_operations, batch_write_duration, batch_write_ops_per_sec });
 
     std.debug.print("Batch read:  ", .{});
     const batch_read_start = std.time.nanoTimestamp();
@@ -199,21 +199,18 @@ fn runBatchOperationBenchmarks(database: *wild.WILD, allocator: std.mem.Allocato
     const batch_read_duration = @as(f64, @floatFromInt(batch_read_end - batch_read_start)) / 1_000_000_000.0;
     const batch_read_ops_per_sec = @as(f64, @floatFromInt(total_operations)) / batch_read_duration;
 
-    std.debug.print("{} ops in {d:.3}s = {d:.0} ops/sec ({} found)\n", .{
-        total_operations, batch_read_duration, batch_read_ops_per_sec, total_found
-    });
+    std.debug.print("{} ops in {d:.3}s = {d:.0} ops/sec ({} found)\n", .{ total_operations, batch_read_duration, batch_read_ops_per_sec, total_found });
 
     const batch_write_latency = (batch_write_duration * 1_000_000_000.0) / @as(f64, @floatFromInt(total_operations));
     const batch_read_latency = (batch_read_duration * 1_000_000_000.0) / @as(f64, @floatFromInt(total_operations));
-    std.debug.print("Batch latency - Write: {d:.0}ns, Read: {d:.0}ns\n", .{batch_write_latency, batch_read_latency});
+    std.debug.print("Batch latency - Write: {d:.0}ns, Read: {d:.0}ns\n", .{ batch_write_latency, batch_read_latency });
 }
 
 fn runMixedWorkloadBenchmark(database: *wild.WILD, allocator: std.mem.Allocator, max_records: u32) !void {
     std.debug.print("\nMixed Workload\n", .{});
 
-    const duration_seconds = 10;  // Increase to 10 seconds for better measurement
-    const batch_size = @min(database.getOptimalBatchSize(), max_records / 4);  // Use smaller batch size to fit within capacity
-
+    const duration_seconds = 10; // Increase to 10 seconds for better measurement
+    const batch_size = @min(database.getOptimalBatchSize(), max_records / 4); // Use smaller batch size to fit within capacity
 
     var keys = try allocator.alloc(u64, batch_size);
     defer allocator.free(keys);
@@ -246,7 +243,7 @@ fn runMixedWorkloadBenchmark(database: *wild.WILD, allocator: std.mem.Allocator,
             // Batch read - allocate results array
             const read_results = try allocator.alloc(?*const flat_hash_storage.CacheLineRecord, batch_size);
             defer allocator.free(read_results);
-            
+
             database.readBatch(keys, read_results);
             read_count += batch_size;
         } else {
@@ -265,7 +262,7 @@ fn runMixedWorkloadBenchmark(database: *wild.WILD, allocator: std.mem.Allocator,
     const actual_duration = @as(f64, @floatFromInt(std.time.nanoTimestamp() - start_time)) / 1_000_000_000.0;
     const ops_per_sec = @as(f64, @floatFromInt(total_operations)) / actual_duration;
 
-    std.debug.print("Mixed workload: {} ops in {d:.2}s = {d:.0} ops/sec\n", .{total_operations, actual_duration, ops_per_sec});
+    std.debug.print("Mixed workload: {} ops in {d:.2}s = {d:.0} ops/sec\n", .{ total_operations, actual_duration, ops_per_sec });
 
     const stats = database.getStats();
     const ops_per_sec_per_core = ops_per_sec / @as(f64, @floatFromInt(stats.physical_cores));

--- a/src/cache_topology.zig
+++ b/src/cache_topology.zig
@@ -119,7 +119,7 @@ fn parseCpuList(allocator: std.mem.Allocator, cpu_list_str: []const u8) ![]u32 {
     while (ranges.next()) |range| {
         if (std.mem.indexOf(u8, range, "-")) |dash_pos| {
             const start = try std.fmt.parseInt(u32, range[0..dash_pos], 10);
-            const end = try std.fmt.parseInt(u32, range[dash_pos + 1..], 10);
+            const end = try std.fmt.parseInt(u32, range[dash_pos + 1 ..], 10);
             var i = start;
             while (i <= end) : (i += 1) {
                 try cpus.append(i);
@@ -161,7 +161,7 @@ fn detectSmtSiblings(allocator: std.mem.Allocator, cpu_id: u32) !u32 {
 
 fn detectCacheLineSize() u32 {
     const builtin = @import("builtin");
-    
+
     if (builtin.cpu.arch == .x86_64) {
         // Use CPUID to get cache line size
         // CPUID leaf 1, EBX bits 15:8 contain cache line size in 8-byte units
@@ -169,22 +169,22 @@ fn detectCacheLineSize() u32 {
         var ebx_out: u32 = undefined;
         var ecx_out: u32 = undefined;
         var edx_out: u32 = undefined;
-        
+
         // CPUID leaf 1
         asm volatile ("cpuid"
             : [eax] "={eax}" (eax_out),
               [ebx] "={ebx}" (ebx_out),
               [ecx] "={ecx}" (ecx_out),
-              [edx] "={edx}" (edx_out)
+              [edx] "={edx}" (edx_out),
             : [leaf] "{eax}" (@as(u32, 1)),
-              [subleaf] "{ecx}" (@as(u32, 0))
+              [subleaf] "{ecx}" (@as(u32, 0)),
             : "memory"
         );
-        
+
         // Extract cache line size from EBX bits 15:8
         const cache_line_units = (ebx_out >> 8) & 0xFF;
         const cache_line_size = cache_line_units * 8;
-        
+
         // Validate reasonable cache line size
         return switch (cache_line_size) {
             16, 32, 64, 128, 256 => cache_line_size,
@@ -257,9 +257,9 @@ pub fn analyzeCacheTopology(allocator: std.mem.Allocator) !CacheTopology {
 
             var size_kb: u64 = 0;
             if (std.mem.endsWith(u8, size_str, "K")) {
-                size_kb = try std.fmt.parseInt(u64, size_str[0..size_str.len-1], 10);
+                size_kb = try std.fmt.parseInt(u64, size_str[0 .. size_str.len - 1], 10);
             } else if (std.mem.endsWith(u8, size_str, "M")) {
-                const mb = try std.fmt.parseInt(u64, size_str[0..size_str.len-1], 10);
+                const mb = try std.fmt.parseInt(u64, size_str[0 .. size_str.len - 1], 10);
                 size_kb = mb * 1024;
             }
 

--- a/src/flat_hash_storage.zig
+++ b/src/flat_hash_storage.zig
@@ -220,10 +220,8 @@ pub const FlatHashStorage = struct {
     }
 
     pub fn clear(self: *Self) void {
-        // Mark all records as invalid and reset count
-        for (self.records) |*record| {
-            record.* = CacheLineRecord.initEmpty();
-        }
+        // Zero out all records with memset - much faster than looping
+        @memset(std.mem.sliceAsBytes(self.records), 0);
         self.count = 0;
     }
 

--- a/src/flat_hash_storage.zig
+++ b/src/flat_hash_storage.zig
@@ -3,28 +3,28 @@ const cache_topology = @import("cache_topology.zig");
 
 // Cache-line-aligned record that fits exactly in one cache line
 pub const CacheLineRecord = extern struct {
-    metadata: u32,               // 4 bytes: 1 bit valid flag + 6 bits length + 25 bits reserved (check first)  
-    key: u64,                    // 8 bytes (check second for key comparison)
-    data: [52]u8,                // 52 bytes data payload (accessed last)
+    metadata: u32, // 4 bytes: 1 bit valid flag + 6 bits length + 25 bits reserved (check first)
+    key: u64, // 8 bytes (check second for key comparison)
+    data: [52]u8, // 52 bytes data payload (accessed last)
     // Total: 64 bytes = exactly 1 cache line
-    
+
     const Self = @This();
-    pub const VALID_FLAG: u32 = 1 << 31;  // Use top bit for valid flag
-    pub const LENGTH_MASK: u32 = 0x3F;    // Bottom 6 bits for length (0-63, enough for 52)
-    
+    pub const VALID_FLAG: u32 = 1 << 31; // Use top bit for valid flag
+    pub const LENGTH_MASK: u32 = 0x3F; // Bottom 6 bits for length (0-63, enough for 52)
+
     pub fn init(key: u64, data: []const u8) !Self {
         if (data.len > 52) return error.DataTooLarge;
-        
+
         var record = Self{
             .metadata = VALID_FLAG | @as(u32, @intCast(data.len)),
             .key = key,
             .data = std.mem.zeroes([52]u8),
         };
-        
+
         @memcpy(record.data[0..data.len], data);
         return record;
     }
-    
+
     pub fn initEmpty() Self {
         return Self{
             .metadata = 0, // Invalid (no VALID_FLAG bit set)
@@ -32,20 +32,20 @@ pub const CacheLineRecord = extern struct {
             .data = std.mem.zeroes([52]u8),
         };
     }
-    
+
     pub fn isValid(self: *const Self) bool {
         return (self.metadata & VALID_FLAG) != 0;
     }
-    
+
     pub fn markInvalid(self: *Self) void {
         self.metadata &= ~VALID_FLAG;
     }
-    
+
     pub fn getData(self: *const Self) []const u8 {
         const len = @as(u32, @intCast(self.metadata & LENGTH_MASK));
         return self.data[0..len];
     }
-    
+
     pub fn getKey(self: *const Self) u64 {
         return self.key;
     }
@@ -54,7 +54,7 @@ pub const CacheLineRecord = extern struct {
 // Unified hash function for both string and integer keys
 pub fn hashKey(key: anytype) u64 {
     const KeyType = @TypeOf(key);
-    
+
     if (KeyType == []const u8) {
         // For string keys, use Wyhash directly
         return std.hash.Wyhash.hash(0, key);
@@ -63,7 +63,7 @@ pub fn hashKey(key: anytype) u64 {
         var h = key;
         h ^= h >> 33;
         h *%= 0xff51afd7ed558ccd;
-        h ^= h >> 33;  
+        h ^= h >> 33;
         h *%= 0xc4ceb9fe1a85ec53;
         h ^= h >> 33;
         return h;
@@ -75,30 +75,26 @@ pub fn hashKey(key: anytype) u64 {
 // Flat hash table with linear probing - no artificial capacity limits
 pub const FlatHashStorage = struct {
     const Self = @This();
-    
-    records: []CacheLineRecord,  // Flat cache-aligned array (alignment handled in allocator)
+
+    records: []CacheLineRecord, // Flat cache-aligned array (alignment handled in allocator)
     capacity: u32,
     count: u32,
     topology: *const cache_topology.CacheTopology,
     allocator: std.mem.Allocator,
-    
+
     // NUMA placement hints (for future optimization)
     numa_domains: u32,
     records_per_domain: u32,
-    
-    pub fn init(
-        allocator: std.mem.Allocator,
-        topology: *const cache_topology.CacheTopology,
-        target_capacity: u64
-    ) !Self {
+
+    pub fn init(allocator: std.mem.Allocator, topology: *const cache_topology.CacheTopology, target_capacity: u64) !Self {
         // Enforce power-of-2 capacity for bitwise operations
         // Round DOWN to largest power-of-2 that fits in L3 cache
         const raw_capacity = @as(u32, @intCast(target_capacity));
-        const capacity = if (std.math.isPowerOfTwo(raw_capacity)) 
-            raw_capacity 
-        else 
+        const capacity = if (std.math.isPowerOfTwo(raw_capacity))
+            raw_capacity
+        else
             std.math.floorPowerOfTwo(u32, raw_capacity);
-        
+
         // Allocate flat cache-aligned array
         // Note: CacheLineRecord is designed for 64-byte cache lines, which matches most modern CPUs
         // If topology shows different cache line size, we should validate compatibility
@@ -106,16 +102,16 @@ pub const FlatHashStorage = struct {
             std.debug.print("Warning: Detected cache line size {} != 64 bytes. Performance may be suboptimal.\n", .{topology.cache_line_size});
         }
         const records = try allocator.alignedAlloc(CacheLineRecord, 64, capacity);
-        
+
         // Initialize all records as invalid/empty
         for (records) |*record| {
             record.* = CacheLineRecord.initEmpty();
         }
-        
+
         // Calculate NUMA domain distribution for future optimization
         const numa_domains = @as(u32, @intCast(topology.l3_domains.len));
         const records_per_domain = capacity / numa_domains;
-        
+
         return Self{
             .records = records,
             .capacity = capacity,
@@ -126,103 +122,111 @@ pub const FlatHashStorage = struct {
             .records_per_domain = records_per_domain,
         };
     }
-    
+
     pub fn deinit(self: *Self) void {
         self.allocator.free(self.records);
     }
-    
+
     // Get hash position with linear probing for reads
     fn findRecord(self: *const Self, key: u64) ?u32 {
         if (self.count == 0) return null;
-        
+
         const start_pos = @as(u32, @intCast(hashKey(key) & (self.capacity - 1)));
         var pos = start_pos;
-        
+
         // Linear probe until we find the key or an empty slot
         // Use bitwise AND for faster wraparound (capacity is power-of-2)
         while (true) {
             const record = &self.records[pos];
-            
+
             if (!record.isValid()) {
                 // Hit empty slot - key doesn't exist
                 return null;
             }
-            
+
             if (record.key == key) {
                 // Found it!
                 return pos;
             }
-            
+
             // Continue probing with bitwise wraparound
             pos = (pos + 1) & (self.capacity - 1);
-            
+
             // If we've wrapped around to start, key doesn't exist
             if (pos == start_pos) break;
         }
-        
+
         return null;
     }
-    
+
     // Find empty slot for insertion with linear probing
     fn findEmptySlot(self: *const Self, key: u64) ?u32 {
         if (self.count >= self.capacity) return null; // Table full
-        
+
         const start_pos = @as(u32, @intCast(hashKey(key) & (self.capacity - 1)));
         var pos = start_pos;
-        
+
         // Linear probe until we find an empty slot or the key (for updates)
         // Use bitwise AND for faster wraparound (capacity is power-of-2)
         while (true) {
             const record = &self.records[pos];
-            
+
             if (!record.isValid() or record.key == key) {
                 // Found empty slot or existing key to update
                 return pos;
             }
-            
+
             // Continue probing with bitwise wraparound
             pos = (pos + 1) & (self.capacity - 1);
-            
+
             // Wrapped around - shouldn't happen if count < capacity
             if (pos == start_pos) break;
         }
-        
+
         return null; // Should never happen if count < capacity
     }
-    
+
     pub inline fn read(self: *const Self, key: u64) ?*const CacheLineRecord {
         const pos = self.findRecord(key) orelse return null;
         return &self.records[pos];
     }
-    
+
     pub inline fn write(self: *Self, key: u64, data: []const u8) !void {
         const pos = self.findEmptySlot(key) orelse return error.TableFull;
-        
+
         const old_record = &self.records[pos];
         const is_update = old_record.isValid() and old_record.key == key;
-        
+
         // Create new record
         self.records[pos] = try CacheLineRecord.init(key, data);
-        
+
         // Update count only for new insertions
         if (!is_update) {
             self.count += 1;
         }
     }
-    
+
     pub inline fn delete(self: *Self, key: u64) bool {
         const pos = self.findRecord(key) orelse return false;
-        
+
         // Mark record as invalid
         self.records[pos].markInvalid();
         self.count -= 1;
-        
+
         // Important: We don't compact the table to maintain O(1) performance
         // The slot remains "tombstoned" until overwritten by a new record
-        
+
         return true;
     }
-    
+
+    pub fn clear(self: *Self) void {
+        // Mark all records as invalid and reset count
+        for (self.records) |*record| {
+            record.* = CacheLineRecord.initEmpty();
+        }
+        self.count = 0;
+    }
+
     pub fn getStats(self: *const Self) StorageStats {
         return StorageStats{
             .total_count = self.count,
@@ -231,16 +235,12 @@ pub const FlatHashStorage = struct {
             .numa_domains = self.numa_domains,
         };
     }
-    
+
     pub fn printDetailedStats(self: *const Self) void {
         const stats = self.getStats();
-        
+
         std.debug.print("\n=== Storage Statistics ===\n", .{});
-        std.debug.print("Capacity: {}/{} records ({d:.1}% full)\n", .{
-            stats.total_count, 
-            stats.total_capacity,
-            stats.load_factor * 100
-        });
+        std.debug.print("Capacity: {}/{} records ({d:.1}% full)\n", .{ stats.total_count, stats.total_capacity, stats.load_factor * 100 });
         std.debug.print("NUMA domains: {}\n", .{stats.numa_domains});
     }
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -167,11 +167,7 @@ fn runCli(database: *wild.WILD, static_alloc: *static_allocator.StaticAllocator)
                 .stats => {
                     const stats = database.getStats();
                     std.debug.print("Database Statistics:\n", .{});
-                    std.debug.print("- Used capacity: {}/{} ({d:.1}%)\n", .{
-                        stats.used_capacity,
-                        stats.total_capacity,
-                        @as(f64, @floatFromInt(stats.used_capacity)) / @as(f64, @floatFromInt(stats.total_capacity)) * 100
-                    });
+                    std.debug.print("- Used capacity: {}/{} ({d:.1}%)\n", .{ stats.used_capacity, stats.total_capacity, @as(f64, @floatFromInt(stats.used_capacity)) / @as(f64, @floatFromInt(stats.total_capacity)) * 100 });
                     std.debug.print("- Optimal batch size: {}\n", .{stats.optimal_batch_size});
                     std.debug.print("- Physical cores: {}\n", .{stats.physical_cores});
                     std.debug.print("- Cache line size: {} bytes\n", .{stats.cache_line_size});
@@ -244,7 +240,7 @@ pub fn main() !void {
     const available_cache_bytes = detected_cache_mb * 1024 * 1024;
     const target_capacity = @as(u64, @intFromFloat(@as(f64, @floatFromInt(available_cache_bytes)) * 0.75 / @as(f64, @floatFromInt(record_size)))); // 75% load factor
 
-    std.debug.print("Detected: {} MB L3 cache, {} records capacity\n", .{detected_cache_mb, target_capacity});
+    std.debug.print("Detected: {} MB L3 cache, {} records capacity\n", .{ detected_cache_mb, target_capacity });
     std.debug.print("Type 'help' for commands\n\n", .{});
 
     // Initialize database with calculated capacity
@@ -262,4 +258,3 @@ pub fn main() !void {
 
     runCli(&database, &static_alloc);
 }
-

--- a/src/root.zig
+++ b/src/root.zig
@@ -20,8 +20,6 @@ pub const flat_hash_storage = @import("flat_hash_storage.zig");
 pub const FlatHashStorage = flat_hash_storage.FlatHashStorage;
 pub const CacheLineRecord = flat_hash_storage.CacheLineRecord;
 
-
-
 test "cache topology analysis" {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
@@ -37,13 +35,13 @@ test "cache topology analysis" {
     // Basic validation
     try testing.expect(topology.total_cpus > 0);
     try testing.expect(topology.shard_mappings.len > 0);
-    
+
     // Test key hashing and shard mapping
     const test_key = "test_key";
     const hash = CacheTopology.hashKey(test_key);
     const shard = topology.getShardForData(hash);
     try testing.expect(shard.shard_id < topology.shard_mappings.len);
-    
+
     // Test convenience method
     const shard2 = topology.getShardForKey(test_key);
     try testing.expect(shard.shard_id == shard2.shard_id);

--- a/src/static_allocator.zig
+++ b/src/static_allocator.zig
@@ -2,17 +2,17 @@ const std = @import("std");
 
 pub const StaticAllocator = struct {
     const Self = @This();
-    
+
     pub const State = enum {
         init,
         static,
         deinit,
     };
-    
+
     state: State,
     backing_allocator: std.mem.Allocator,
     allocated_memory: std.ArrayList([]u8),
-    
+
     pub fn init(backing_allocator: std.mem.Allocator) Self {
         return Self{
             .state = .init,
@@ -20,27 +20,27 @@ pub const StaticAllocator = struct {
             .allocated_memory = std.ArrayList([]u8).init(backing_allocator),
         };
     }
-    
+
     pub fn transitionToStatic(self: *Self) void {
         std.debug.assert(self.state == .init);
         self.state = .static;
     }
-    
+
     pub fn transitionToDeinit(self: *Self) void {
         std.debug.assert(self.state == .static);
         self.state = .deinit;
     }
-    
+
     pub fn deinit(self: *Self) void {
         std.debug.assert(self.state == .deinit);
-        
+
         // Free all allocated memory
         for (self.allocated_memory.items) |memory| {
             self.backing_allocator.free(memory);
         }
         self.allocated_memory.deinit();
     }
-    
+
     pub fn allocator(self: *Self) std.mem.Allocator {
         return std.mem.Allocator{
             .ptr = self,
@@ -52,58 +52,58 @@ pub const StaticAllocator = struct {
             },
         };
     }
-    
+
     fn alloc(ctx: *anyopaque, len: usize, ptr_align: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
         const self: *Self = @ptrCast(@alignCast(ctx));
-        
+
         // Only allow allocation during init state
         if (self.state != .init) {
             std.debug.panic("StaticAllocator: allocation attempted in {} state (only allowed in init state)", .{self.state});
         }
-        
+
         const result = self.backing_allocator.rawAlloc(len, ptr_align, ret_addr) orelse return null;
         const memory = result[0..len];
-        
+
         // Track allocated memory for cleanup
         self.allocated_memory.append(memory) catch {
             self.backing_allocator.rawFree(memory, ptr_align, ret_addr);
             return null;
         };
-        
+
         return result;
     }
-    
+
     fn resize(ctx: *anyopaque, buf: []u8, buf_align: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
         _ = ctx;
         _ = buf;
         _ = buf_align;
         _ = new_len;
         _ = ret_addr;
-        
+
         // Never allow resize - all memory must be allocated upfront
         return false;
     }
-    
+
     fn free(ctx: *anyopaque, buf: []u8, buf_align: std.mem.Alignment, ret_addr: usize) void {
         const self: *Self = @ptrCast(@alignCast(ctx));
-        
+
         // Allow free during init (for temporary allocations) and deinit states
         // Static state should not free anything
         if (self.state == .static) {
             std.debug.panic("StaticAllocator: free attempted in static state (not allowed)", .{});
         }
-        
+
         self.backing_allocator.rawFree(buf, buf_align, ret_addr);
     }
-    
+
     fn remap(ctx: *anyopaque, buf: []u8, buf_align: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
         const self: *Self = @ptrCast(@alignCast(ctx));
-        
+
         // Only allow remap during init state
         if (self.state != .init) {
             std.debug.panic("StaticAllocator: remap attempted in {} state (only allowed in init state)", .{self.state});
         }
-        
+
         return self.backing_allocator.rawRemap(buf, buf_align, new_len, ret_addr);
     }
 };

--- a/src/wild.zig
+++ b/src/wild.zig
@@ -6,20 +6,19 @@ const static_allocator = @import("static_allocator.zig");
 // WILD Database - Cache-Resident Ultra-High-Performance Key-Value Store
 pub const WILD = struct {
     const Self = @This();
-    
+
     // Core storage engine
     storage: flat_hash_storage.FlatHashStorage,
     cache_topology: *cache_topology.CacheTopology,
     allocator: std.mem.Allocator,
-    
-    
+
     // Configuration
     target_capacity: u64,
-    
+
     pub const Config = struct {
         target_capacity: u64,
     };
-    
+
     pub const Stats = struct {
         load_factor: f32,
         used_capacity: u32,
@@ -28,31 +27,27 @@ pub const WILD = struct {
         cache_line_size: u32,
         optimal_batch_size: u32,
     };
-    
+
     // Initialize WILD database
     pub fn init(allocator: std.mem.Allocator, config: Config) !Self {
         // Database receives static allocator from caller
         // Caller is responsible for managing arena + static allocator lifecycle
-        
+
         // Detect CPU topology
         const topology_ptr = try allocator.create(cache_topology.CacheTopology);
         topology_ptr.* = try cache_topology.analyzeCacheTopology(allocator);
-        
+
         // Calculate total L3 cache size for validation
         var total_l3_cache_kb: u64 = 0;
         for (topology_ptr.l3_domains) |domain| {
             total_l3_cache_kb += domain.cache_size_kb;
         }
-        
+
         // Initialize flat hash storage using static allocator
-        const storage = try flat_hash_storage.FlatHashStorage.init(
-            allocator, 
-            topology_ptr, 
-            config.target_capacity
-        );
-        
+        const storage = try flat_hash_storage.FlatHashStorage.init(allocator, topology_ptr, config.target_capacity);
+
         // Note: Caller will transition static allocator to static state after init
-        
+
         return Self{
             .storage = storage,
             .cache_topology = topology_ptr,
@@ -60,7 +55,7 @@ pub const WILD = struct {
             .target_capacity = config.target_capacity,
         };
     }
-    
+
     pub fn deinit(self: *Self) void {
         // Note: Caller will transition static allocator to deinit state
         self.storage.deinit();
@@ -68,66 +63,70 @@ pub const WILD = struct {
         self.allocator.destroy(self.cache_topology);
         // Note: Caller handles static allocator and arena cleanup
     }
-    
+
     // Core single operations - no stats overhead
     pub inline fn read(self: *Self, key: u64) !?*const flat_hash_storage.CacheLineRecord {
         return self.storage.read(key);
     }
-    
+
     pub inline fn write(self: *Self, key: u64, data: []const u8) !void {
         try self.storage.write(key, data);
     }
-    
+
     pub inline fn delete(self: *Self, key: u64) !bool {
         return self.storage.delete(key);
     }
-    
+
+    pub inline fn clear(self: *Self) void {
+        self.storage.clear();
+    }
+
     // Batch operations for maximum performance - caller must provide result array
     pub fn readBatch(self: *Self, keys: []const u64, results: []?*const flat_hash_storage.CacheLineRecord) void {
         std.debug.assert(keys.len == results.len);
-        
+
         // Simple loop - cache-line access is already optimized
         for (keys, 0..) |key, i| {
             results[i] = self.storage.read(key);
         }
     }
-    
+
     // Simplified write batch - no complex batching needed with cache-line approach
     pub fn writeBatch(self: *Self, keys: []const u64, data_items: []const []const u8) !void {
         std.debug.assert(keys.len == data_items.len);
-        
+
         // Simple loop over writes
         for (keys, data_items) |key, data| {
             try self.storage.write(key, data);
         }
     }
-    
+
     pub fn deleteBatch(self: *Self, keys: []const u64) ![]bool {
         const results = try self.allocator.alloc(bool, keys.len);
-        
+
         for (keys, 0..) |key, i| {
             results[i] = self.storage.delete(key);
         }
-        
+
         return results;
     }
-    
+
     // Convenience methods for string keys - no double hashing
     pub fn readString(self: *Self, key: []const u8) !?*const flat_hash_storage.CacheLineRecord {
         const hash = flat_hash_storage.hashKey(key);
         return self.read(hash);
     }
-    
+
     pub fn writeString(self: *Self, key: []const u8, data: []const u8) !void {
         const hash = flat_hash_storage.hashKey(key);
         return self.write(hash, data);
     }
-    
+
     pub fn deleteString(self: *Self, key: []const u8) !bool {
         const hash = flat_hash_storage.hashKey(key);
         return self.delete(hash);
     }
-    
+
     // Get optimal batch size for this hardware - simplified for cache-line approach
     pub fn getOptimalBatchSize(self: *const Self) u32 {
         // With cache-line storage, batch size can be larger since we don't have bucket limitations
@@ -135,11 +134,11 @@ pub const WILD = struct {
         const cores_multiplier = @max(1, self.cache_topology.total_physical_cores / 2);
         return base_batch_size * cores_multiplier;
     }
-    
+
     // Basic statistics - no timing overhead
     pub fn getStats(self: *const Self) Stats {
         const storage_stats = self.storage.getStats();
-        
+
         return Stats{
             .load_factor = storage_stats.load_factor,
             .used_capacity = storage_stats.total_count,
@@ -149,28 +148,24 @@ pub const WILD = struct {
             .optimal_batch_size = self.getOptimalBatchSize(),
         };
     }
-    
+
     // Print hardware and storage report - no performance timing
     pub fn printHardwareReport(self: *const Self) void {
         const stats = self.getStats();
-        
+
         // Print storage details first
         self.storage.printDetailedStats();
-        
+
         std.debug.print("\n=== WILD Hardware Report ===\n", .{});
         std.debug.print("Hardware Configuration:\n", .{});
         std.debug.print("- Physical cores: {}\n", .{stats.physical_cores});
         std.debug.print("- Cache line size: {} bytes\n", .{stats.cache_line_size});
         std.debug.print("- Optimal batch size: {}\n", .{stats.optimal_batch_size});
-        
+
         std.debug.print("\nStorage Statistics:\n", .{});
-        std.debug.print("- Used capacity: {}/{} ({d:.1}%)\n", .{ 
-            stats.used_capacity, 
-            stats.total_capacity, 
-            stats.load_factor * 100 
-        });
+        std.debug.print("- Used capacity: {}/{} ({d:.1}%)\n", .{ stats.used_capacity, stats.total_capacity, stats.load_factor * 100 });
     }
-    
+
     // Hash key utility - unified interface
     pub fn hashKey(key: anytype) u64 {
         return flat_hash_storage.hashKey(key);


### PR DESCRIPTION
Fixes most issues reported in #1

## Summary by Sourcery

Implement storage clearing in both FlatHashStorage and WILD API and update benchmark suite to reset the database between runs and tune workload sizes to avoid table-full errors.

New Features:
- Add clear method to FlatHashStorage to reset all records and count
- Expose clear method on WILD to allow database-wide storage reset

Bug Fixes:
- Prevent table-full errors in benchmarks by clearing storage between test phases

Enhancements:
- Adjust benchmark operation counts dynamically based on safe capacity
- Use max_batches directly for batch benchmarks to respect capacity limits
- Refine single-operation benchmarks to use half of max_records for load control