### PR TITLE
Add write-ahead log for durability

### DIFF
--- a/performance_benchmark.zig
+++ b/performance_benchmark.zig
@@ -1,0 +1,405 @@
+const std = @import("std");
+const wild = @import("src/wild.zig");
+const flat_hash_storage = @import("src/flat_hash_storage.zig");
+const wal = @import("src/wal.zig");
+const snapshot = @import("src/snapshot.zig");
+const static_allocator = @import("src/static_allocator.zig");
+
+// Performance benchmark for WILD database
+// Tests core performance claims and durability overhead
+
+const BenchmarkConfig = struct {
+    target_capacity: u64 = 100_000,
+    warm_up_iterations: u64 = 10_000,
+    benchmark_iterations: u64 = 1_000_000,
+    batch_size: u32 = 1000,
+    test_data_size: u32 = 32, // bytes per record
+    enable_wal: bool = true,
+    enable_snapshots: bool = true,
+};
+
+const BenchmarkResults = struct {
+    single_write_ns: f64,
+    single_read_ns: f64,
+    batch_write_ns_per_op: f64,
+    batch_read_ns_per_op: f64,
+    memory_usage_mb: f64,
+    wal_overhead_ns: f64,
+    recovery_time_ms: f64,
+    throughput_ops_per_sec: f64,
+    load_factor: f32,
+};
+
+pub fn main() !void {
+    std.debug.print("=== WILD Performance Benchmark Suite ===\n", .{});
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Clean up test files
+    cleanup() catch {};
+
+    const config = BenchmarkConfig{};
+
+    // Benchmark 1: Core performance without durability
+    std.debug.print("\n--- Benchmark 1: Core Performance (No Durability) ---\n", .{});
+    const core_results = try runCoreBenchmark(allocator, config, false, false);
+    printResults("Core Performance", core_results);
+
+    // Benchmark 2: Performance with WAL durability
+    std.debug.print("\n--- Benchmark 2: Performance with WAL Durability ---\n", .{});
+    const wal_results = try runCoreBenchmark(allocator, config, true, false);
+    printResults("WAL Durability", wal_results);
+
+    // Benchmark 3: Performance with WAL + Snapshots
+    std.debug.print("\n--- Benchmark 3: Performance with WAL + Snapshots ---\n", .{});
+    const full_results = try runCoreBenchmark(allocator, config, true, true);
+    printResults("Full Durability", full_results);
+
+    // Benchmark 4: Recovery performance
+    std.debug.print("\n--- Benchmark 4: Recovery Performance ---\n", .{});
+    try runRecoveryBenchmark(allocator, config);
+
+    // Benchmark 5: Load factor vs performance
+    std.debug.print("\n--- Benchmark 5: Load Factor Impact ---\n", .{});
+    try runLoadFactorBenchmark(allocator, config);
+
+    // Summary
+    std.debug.print("\n=== Performance Summary ===\n", .{});
+    std.debug.print("Core Write Latency:     {d:.1} ns\n", .{core_results.single_write_ns});
+    std.debug.print("WAL Overhead:           {d:.1} ns ({d:.1}% impact)\n", .{ wal_results.single_write_ns - core_results.single_write_ns, ((wal_results.single_write_ns - core_results.single_write_ns) / core_results.single_write_ns) * 100 });
+    std.debug.print("Target (42ns):          {s} {s}\n", .{ if (core_results.single_write_ns <= 42.0) "✓ ACHIEVED" else "❌ MISSED", if (core_results.single_write_ns <= 42.0) "" else "(Performance regression detected)" });
+
+    std.debug.print("\n=== Benchmark Complete ===\n", .{});
+}
+
+fn cleanup() !void {
+    const paths = [_][]const u8{
+        "/tmp/benchmark_wild.wal",
+        "/tmp/benchmark_snapshots",
+    };
+
+    for (paths) |path| {
+        std.fs.cwd().deleteFile(path) catch {};
+        std.fs.cwd().deleteTree(path) catch {};
+    }
+}
+
+fn runCoreBenchmark(allocator: std.mem.Allocator, config: BenchmarkConfig, enable_wal: bool, enable_snapshots: bool) !BenchmarkResults {
+    // Create static allocator setup
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    var static_alloc = static_allocator.StaticAllocator.init(arena_allocator);
+
+    // Initialize database
+    const db_config = wild.WILD.Config{
+        .target_capacity = config.target_capacity,
+    };
+
+    var db = try wild.WILD.init(static_alloc.allocator(), db_config);
+    defer {
+        static_alloc.transitionToDeinit();
+        db.deinit();
+    }
+
+    // Enable durability if requested
+    if (enable_wal) {
+        const wal_config = wal.DurabilityManager.Config{
+            .wal_path = "/tmp/benchmark_wild.wal",
+            .max_threads = 4,
+            .ring_buffer_size = 4096,
+            .batch_buffer_count = 16,
+            .io_uring_entries = 64,
+        };
+        try db.enableDurability(wal_config);
+    }
+
+    // Enable snapshots if requested
+    if (enable_snapshots) {
+        const snapshot_config = snapshot.SnapshotManager.Config{
+            .snapshot_dir = "/tmp/benchmark_snapshots",
+            .max_snapshots = 5,
+            .snapshot_interval_seconds = 300, // 5 minutes
+        };
+        try db.enableSnapshots(snapshot_config);
+    }
+
+    // Freeze static allocator
+    static_alloc.transitionToStatic();
+
+    // Prepare test data
+    const test_data = try allocator.alloc(u8, config.test_data_size);
+    defer allocator.free(test_data);
+    @memset(test_data, 0xAB); // Fill with test pattern
+
+    var prng = std.Random.DefaultPrng.init(@as(u64, @intCast(std.time.nanoTimestamp())));
+    const random = prng.random();
+
+    std.debug.print("Warming up with {} iterations...\n", .{config.warm_up_iterations});
+
+    // Warm-up phase
+    var i: u64 = 0;
+    while (i < config.warm_up_iterations) : (i += 1) {
+        const key = random.int(u64);
+        db.write(key, test_data) catch |err| switch (err) {
+            error.TableFull => break, // Expected at high load factors
+            else => return err,
+        };
+    }
+
+    // Single operation benchmarks
+    std.debug.print("Benchmarking single operations...\n", .{});
+
+    const write_times = try allocator.alloc(u64, @intCast(config.benchmark_iterations));
+    defer allocator.free(write_times);
+    const read_times = try allocator.alloc(u64, @intCast(config.benchmark_iterations));
+    defer allocator.free(read_times);
+
+    const keys = try allocator.alloc(u64, @intCast(config.benchmark_iterations));
+    defer allocator.free(keys);
+
+    // Generate unique keys
+    for (keys) |*key| {
+        key.* = random.int(u64);
+    }
+
+    // Benchmark writes
+    i = 0;
+    while (i < config.benchmark_iterations and i < keys.len) : (i += 1) {
+        const start_time = std.time.nanoTimestamp();
+        db.write(keys[i], test_data) catch |err| switch (err) {
+            error.TableFull => break,
+            else => return err,
+        };
+        const end_time = std.time.nanoTimestamp();
+        write_times[i] = @as(u64, @intCast(end_time - start_time));
+    }
+    const actual_writes = i;
+
+    // Wait for WAL to catch up if enabled
+    if (enable_wal) {
+        std.time.sleep(50_000_000); // 50ms
+    }
+
+    // Benchmark reads
+    i = 0;
+    while (i < actual_writes) : (i += 1) {
+        const start_time = std.time.nanoTimestamp();
+        _ = try db.read(keys[i]);
+        const end_time = std.time.nanoTimestamp();
+        read_times[i] = @as(u64, @intCast(end_time - start_time));
+    }
+
+    // Calculate statistics
+    const write_avg = calculateAverage(write_times[0..actual_writes]);
+    const read_avg = calculateAverage(read_times[0..actual_writes]);
+
+    // Batch operation benchmarks
+    std.debug.print("Benchmarking batch operations...\n", .{});
+
+    const batch_keys = try allocator.alloc(u64, config.batch_size);
+    defer allocator.free(batch_keys);
+    const batch_data = try allocator.alloc([]const u8, config.batch_size);
+    defer allocator.free(batch_data);
+
+    for (batch_keys) |*key| key.* = random.int(u64);
+    for (batch_data) |*data| data.* = test_data;
+
+    const batch_start = std.time.nanoTimestamp();
+    try db.writeBatch(batch_keys, batch_data);
+    const batch_end = std.time.nanoTimestamp();
+
+    const batch_write_time = @as(f64, @floatFromInt(@as(u64, @intCast(batch_end - batch_start))));
+    const batch_write_per_op = batch_write_time / @as(f64, @floatFromInt(config.batch_size));
+
+    // Read batch benchmark
+    const read_results = try allocator.alloc(?*const flat_hash_storage.CacheLineRecord, config.batch_size);
+    defer allocator.free(read_results);
+
+    const batch_read_start = std.time.nanoTimestamp();
+    db.readBatch(batch_keys, read_results);
+    const batch_read_end = std.time.nanoTimestamp();
+
+    const batch_read_time = @as(f64, @floatFromInt(@as(u64, @intCast(batch_read_end - batch_read_start))));
+    const batch_read_per_op = batch_read_time / @as(f64, @floatFromInt(config.batch_size));
+
+    // Calculate throughput
+    const total_time_sec = @as(f64, @floatFromInt(actual_writes)) * write_avg / 1_000_000_000.0;
+    const throughput = @as(f64, @floatFromInt(actual_writes)) / total_time_sec;
+
+    // Get final statistics
+    const stats = db.getStats();
+    const memory_usage = @as(f64, @floatFromInt(stats.total_capacity * @sizeOf(flat_hash_storage.CacheLineRecord))) / (1024.0 * 1024.0);
+
+    return BenchmarkResults{
+        .single_write_ns = write_avg,
+        .single_read_ns = read_avg,
+        .batch_write_ns_per_op = batch_write_per_op,
+        .batch_read_ns_per_op = batch_read_per_op,
+        .memory_usage_mb = memory_usage,
+        .wal_overhead_ns = 0, // Calculated externally
+        .recovery_time_ms = 0, // Set by recovery benchmark
+        .throughput_ops_per_sec = throughput,
+        .load_factor = stats.load_factor,
+    };
+}
+
+fn runRecoveryBenchmark(allocator: std.mem.Allocator, _: BenchmarkConfig) !void {
+    // Create database with data
+    {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+        var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = 10_000 });
+        defer {
+            static_alloc.transitionToDeinit();
+            db.deinit();
+        }
+
+        const wal_config = wal.DurabilityManager.Config{
+            .wal_path = "/tmp/benchmark_wild.wal",
+            .max_threads = 4,
+            .ring_buffer_size = 2048,
+            .batch_buffer_count = 8,
+            .io_uring_entries = 32,
+        };
+        try db.enableDurability(wal_config);
+
+        const snapshot_config = snapshot.SnapshotManager.Config{
+            .snapshot_dir = "/tmp/benchmark_snapshots",
+            .max_snapshots = 3,
+            .snapshot_interval_seconds = 1,
+        };
+        try db.enableSnapshots(snapshot_config);
+
+        static_alloc.transitionToStatic();
+
+        // Fill database with test data
+        std.debug.print("Creating test dataset for recovery benchmark...\n", .{});
+        var i: u64 = 0;
+        while (i < 5000) : (i += 1) {
+            try db.write(i, "recovery_test_data_value");
+        }
+
+        // Wait for WAL
+        std.time.sleep(20_000_000);
+
+        // Create snapshot
+        try db.createSnapshot();
+
+        // Add more data after snapshot
+        while (i < 7000) : (i += 1) {
+            try db.write(i, "post_snapshot_data_value");
+        }
+
+        std.time.sleep(20_000_000); // Let WAL catch up
+    }
+
+    // Now benchmark recovery
+    {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+        var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = 10_000 });
+        defer {
+            static_alloc.transitionToDeinit();
+            db.deinit();
+        }
+
+        const snapshot_config = snapshot.SnapshotManager.Config{
+            .snapshot_dir = "/tmp/benchmark_snapshots",
+            .max_snapshots = 3,
+            .snapshot_interval_seconds = 1,
+        };
+        try db.enableSnapshots(snapshot_config);
+
+        static_alloc.transitionToStatic();
+
+        std.debug.print("Benchmarking recovery time...\n", .{});
+        const recovery_start = std.time.nanoTimestamp();
+        try db.performRecovery("/tmp/benchmark_wild.wal");
+        const recovery_end = std.time.nanoTimestamp();
+
+        const recovery_time_ns = @as(u64, @intCast(recovery_end - recovery_start));
+        const recovery_time_ms = @as(f64, @floatFromInt(recovery_time_ns)) / 1_000_000.0;
+
+        const stats = db.getStats();
+        std.debug.print("Recovery completed in {d:.2} ms\n", .{recovery_time_ms});
+        std.debug.print("Recovered {} records ({d:.1}% load factor)\n", .{ stats.used_capacity, stats.load_factor * 100 });
+    }
+}
+
+fn runLoadFactorBenchmark(allocator: std.mem.Allocator, _: BenchmarkConfig) !void {
+    std.debug.print("Testing performance at different load factors...\n", .{});
+
+    const load_factors = [_]f32{ 0.25, 0.5, 0.75, 0.9 };
+    const test_data = "load_factor_test_data";
+
+    for (load_factors) |target_load_factor| {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+        var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = 10_000 });
+        defer {
+            static_alloc.transitionToDeinit();
+            db.deinit();
+        }
+
+        static_alloc.transitionToStatic();
+
+        // Fill to target load factor
+        const target_count = @as(u64, @intFromFloat(@as(f64, @floatFromInt(10_000)) * target_load_factor));
+        var i: u64 = 0;
+        while (i < target_count) : (i += 1) {
+            try db.write(i, test_data);
+        }
+
+        // Benchmark at this load factor
+        const times = try allocator.alloc(u64, 1000);
+        defer allocator.free(times);
+
+        var prng = std.Random.DefaultPrng.init(@as(u64, @intCast(std.time.nanoTimestamp())));
+        const random = prng.random();
+
+        for (times) |*time| {
+            const key = random.intRangeAtMost(u64, 0, target_count - 1);
+            const start = std.time.nanoTimestamp();
+            _ = try db.read(key);
+            const end = std.time.nanoTimestamp();
+            time.* = @as(u64, @intCast(end - start));
+        }
+
+        const avg_time = calculateAverage(times);
+        const stats = db.getStats();
+
+        std.debug.print("Load Factor {d:.1}%: {d:.1} ns avg read time ({} records)\n", .{ stats.load_factor * 100, avg_time, stats.used_capacity });
+    }
+}
+
+fn calculateAverage(times: []const u64) f64 {
+    if (times.len == 0) return 0;
+
+    var sum: u64 = 0;
+    for (times) |time| {
+        sum += time;
+    }
+
+    return @as(f64, @floatFromInt(sum)) / @as(f64, @floatFromInt(times.len));
+}
+
+fn printResults(label: []const u8, results: BenchmarkResults) void {
+    std.debug.print("\n{s} Results:\n", .{label});
+    std.debug.print("  Single Write:     {d:.1} ns\n", .{results.single_write_ns});
+    std.debug.print("  Single Read:      {d:.1} ns\n", .{results.single_read_ns});
+    std.debug.print("  Batch Write:      {d:.1} ns/op\n", .{results.batch_write_ns_per_op});
+    std.debug.print("  Batch Read:       {d:.1} ns/op\n", .{results.batch_read_ns_per_op});
+    std.debug.print("  Throughput:       {d:.0} ops/sec\n", .{results.throughput_ops_per_sec});
+    std.debug.print("  Memory Usage:     {d:.1} MB\n", .{results.memory_usage_mb});
+    std.debug.print("  Load Factor:      {d:.1}%\n", .{results.load_factor * 100});
+}

--- a/quick_benchmark.zig
+++ b/quick_benchmark.zig
@@ -1,0 +1,127 @@
+const std = @import("std");
+const wild = @import("src/wild.zig");
+const flat_hash_storage = @import("src/flat_hash_storage.zig");
+const static_allocator = @import("src/static_allocator.zig");
+
+pub fn main() !void {
+    std.debug.print("=== WILD Quick Performance Test ===\n", .{});
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Create static allocator setup
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+    // Initialize database - smaller capacity for testing
+    const db_config = wild.WILD.Config{
+        .target_capacity = 10_000, // Smaller for focused testing
+    };
+
+    var db = try wild.WILD.init(static_alloc.allocator(), db_config);
+    defer {
+        static_alloc.transitionToDeinit();
+        db.deinit();
+    }
+
+    static_alloc.transitionToStatic();
+
+    // Test data
+    const test_data = "benchmark_test_data_32_bytes_!";
+    var prng = std.Random.DefaultPrng.init(@as(u64, @intCast(std.time.nanoTimestamp())));
+    const random = prng.random();
+
+    std.debug.print("Testing core write performance (no durability)...\n", .{});
+
+    // Generate unique keys for consistent testing
+    const num_tests = 1000;
+    var keys: [num_tests]u64 = undefined;
+    for (&keys) |*key| {
+        key.* = random.int(u64);
+    }
+
+    // Benchmark write latency
+    var write_times: [num_tests]u64 = undefined;
+
+    for (keys, 0..) |key, i| {
+        const start_time = std.time.nanoTimestamp();
+        try db.write(key, test_data);
+        const end_time = std.time.nanoTimestamp();
+        write_times[i] = @as(u64, @intCast(end_time - start_time));
+    }
+
+    // Calculate statistics
+    var total_time: u64 = 0;
+    var min_time: u64 = std.math.maxInt(u64);
+    var max_time: u64 = 0;
+
+    for (write_times) |time| {
+        total_time += time;
+        if (time < min_time) min_time = time;
+        if (time > max_time) max_time = time;
+    }
+
+    const avg_time_ns = @as(f64, @floatFromInt(total_time)) / @as(f64, @floatFromInt(num_tests));
+
+    std.debug.print("\n=== Core Write Performance Results ===\n", .{});
+    std.debug.print("Operations:     {}\n", .{num_tests});
+    std.debug.print("Average:        {d:.1} ns/write\n", .{avg_time_ns});
+    std.debug.print("Minimum:        {} ns\n", .{min_time});
+    std.debug.print("Maximum:        {} ns\n", .{max_time});
+    std.debug.print("Target (42ns):  {s}\n", .{if (avg_time_ns <= 42.0) "✓ ACHIEVED" else "❌ MISSED"});
+
+    // Test read performance
+    std.debug.print("\nTesting read performance...\n", .{});
+    var read_times: [num_tests]u64 = undefined;
+
+    for (keys, 0..) |key, i| {
+        const start_time = std.time.nanoTimestamp();
+        _ = try db.read(key);
+        const end_time = std.time.nanoTimestamp();
+        read_times[i] = @as(u64, @intCast(end_time - start_time));
+    }
+
+    var total_read_time: u64 = 0;
+    var min_read_time: u64 = std.math.maxInt(u64);
+    var max_read_time: u64 = 0;
+
+    for (read_times) |time| {
+        total_read_time += time;
+        if (time < min_read_time) min_read_time = time;
+        if (time > max_read_time) max_read_time = time;
+    }
+
+    const avg_read_time_ns = @as(f64, @floatFromInt(total_read_time)) / @as(f64, @floatFromInt(num_tests));
+
+    std.debug.print("\n=== Read Performance Results ===\n", .{});
+    std.debug.print("Average:        {d:.1} ns/read\n", .{avg_read_time_ns});
+    std.debug.print("Minimum:        {} ns\n", .{min_read_time});
+    std.debug.print("Maximum:        {} ns\n", .{max_read_time});
+
+    // Database statistics
+    const stats = db.getStats();
+    std.debug.print("\n=== Database Statistics ===\n", .{});
+    std.debug.print("Load Factor:    {d:.1}%\n", .{stats.load_factor * 100});
+    std.debug.print("Used/Total:     {}/{}\n", .{ stats.used_capacity, stats.total_capacity });
+    std.debug.print("Memory Usage:   {d:.1} MB\n", .{@as(f64, @floatFromInt(stats.total_capacity * @sizeOf(flat_hash_storage.CacheLineRecord))) / (1024.0 * 1024.0)});
+
+    // Hardware information
+    std.debug.print("\n=== Hardware Information ===\n", .{});
+    std.debug.print("Physical Cores: {}\n", .{stats.physical_cores});
+    std.debug.print("Cache Line:     {} bytes\n", .{stats.cache_line_size});
+    std.debug.print("Record Size:    {} bytes\n", .{@sizeOf(flat_hash_storage.CacheLineRecord)});
+
+    std.debug.print("\n=== Performance Analysis ===\n", .{});
+    if (avg_time_ns <= 42.0) {
+        std.debug.print("🎉 SUCCESS: 42ns target ACHIEVED!\n", .{});
+        std.debug.print("   Write performance: {d:.1}ns (target: ≤42ns)\n", .{avg_time_ns});
+    } else {
+        std.debug.print("⚠️  WARNING: 42ns target missed\n", .{});
+        std.debug.print("   Write performance: {d:.1}ns (target: ≤42ns)\n", .{avg_time_ns});
+        std.debug.print("   Difference: +{d:.1}ns\n", .{avg_time_ns - 42.0});
+    }
+
+    std.debug.print("\n=== Quick Benchmark Complete ===\n", .{});
+}

--- a/recovery_benchmark.zig
+++ b/recovery_benchmark.zig
@@ -1,0 +1,357 @@
+const std = @import("std");
+const wild = @import("src/wild.zig");
+const wal = @import("src/wal.zig");
+const snapshot = @import("src/snapshot.zig");
+const static_allocator = @import("src/static_allocator.zig");
+
+pub fn main() !void {
+    std.debug.print("=== WILD Recovery Performance Benchmark ===\n", .{});
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Clean up test files
+    cleanup() catch {};
+
+    // Benchmark 1: WAL-only recovery
+    try benchmarkWALOnlyRecovery(allocator);
+
+    // Benchmark 2: Snapshot-only recovery
+    try benchmarkSnapshotOnlyRecovery(allocator);
+
+    // Benchmark 3: Snapshot + WAL recovery
+    try benchmarkSnapshotPlusWALRecovery(allocator);
+
+    // Benchmark 4: WAL write verification
+    try benchmarkWALWriteVerification(allocator);
+
+    std.debug.print("\n=== Recovery Benchmark Complete ===\n", .{});
+}
+
+fn cleanup() !void {
+    const paths = [_][]const u8{
+        "/tmp/recovery_test.wal",
+        "/tmp/recovery_snapshots",
+    };
+
+    for (paths) |path| {
+        std.fs.cwd().deleteFile(path) catch {};
+        std.fs.cwd().deleteTree(path) catch {};
+    }
+}
+
+fn benchmarkWALOnlyRecovery(allocator: std.mem.Allocator) !void {
+    std.debug.print("\n--- Benchmark 1: WAL-Only Recovery ---\n", .{});
+
+    // First, create a database with WAL data
+    {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+        var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = 10_000 });
+        defer {
+            static_alloc.transitionToDeinit();
+            db.deinit();
+        }
+
+        const wal_config = wal.DurabilityManager.Config{
+            .wal_path = "/tmp/recovery_test.wal",
+            .max_threads = 4,
+            .ring_buffer_size = 2048,
+            .batch_buffer_count = 8,
+            .io_uring_entries = 32,
+        };
+        try db.enableDurability(wal_config);
+
+        static_alloc.transitionToStatic();
+
+        std.debug.print("Creating test data with WAL...\n", .{});
+
+        // Fill database with test data
+        var i: u64 = 0;
+        while (i < 5000) : (i += 1) {
+            try db.write(i, "wal_only_recovery_test_data");
+        }
+
+        // Wait for WAL to flush
+        std.time.sleep(100_000_000); // 100ms
+
+        if (db.getDurabilityStatsNoAlloc()) |dur_stats| {
+            std.debug.print("WAL Status: {} batches, {} entries, {d:.1} MB\n", .{ dur_stats.batches_written, dur_stats.total_entries_written, @as(f64, @floatFromInt(dur_stats.wal_size_bytes)) / (1024.0 * 1024.0) });
+        }
+    }
+
+    // Check if WAL file exists
+    const wal_file = std.fs.cwd().openFile("/tmp/recovery_test.wal", .{}) catch |err| {
+        std.debug.print("❌ WAL file not found: {}\n", .{err});
+        return;
+    };
+    defer wal_file.close();
+
+    const wal_size = try wal_file.getEndPos();
+    std.debug.print("WAL file size: {} bytes\n", .{wal_size});
+
+    // Now benchmark recovery from WAL only
+    const recovery_times = [_]struct { name: []const u8, capacity: u64 }{
+        .{ .name = "10K capacity", .capacity = 10_000 },
+        .{ .name = "25K capacity", .capacity = 25_000 },
+        .{ .name = "50K capacity", .capacity = 50_000 },
+    };
+
+    for (recovery_times) |scenario| {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+        var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = scenario.capacity });
+        defer {
+            static_alloc.transitionToDeinit();
+            db.deinit();
+        }
+
+        const snapshot_config = snapshot.SnapshotManager.Config{
+            .snapshot_dir = "/tmp/empty_snapshots", // Empty directory
+            .max_snapshots = 5,
+            .snapshot_interval_seconds = 300,
+        };
+        try db.enableSnapshots(snapshot_config);
+
+        static_alloc.transitionToStatic();
+
+        const recovery_start = std.time.nanoTimestamp();
+        try db.performRecovery("/tmp/recovery_test.wal");
+        const recovery_end = std.time.nanoTimestamp();
+
+        const recovery_time_ms = @as(f64, @floatFromInt(@as(u64, @intCast(recovery_end - recovery_start)))) / 1_000_000.0;
+        const stats = db.getStats();
+
+        std.debug.print("  {s}: {d:.1} ms ({} records recovered)\n", .{ scenario.name, recovery_time_ms, stats.used_capacity });
+    }
+}
+
+fn benchmarkSnapshotOnlyRecovery(allocator: std.mem.Allocator) !void {
+    std.debug.print("\n--- Benchmark 2: Snapshot-Only Recovery ---\n", .{});
+
+    // Create database with snapshot
+    {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+        var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = 25_000 });
+        defer {
+            static_alloc.transitionToDeinit();
+            db.deinit();
+        }
+
+        const snapshot_config = snapshot.SnapshotManager.Config{
+            .snapshot_dir = "/tmp/recovery_snapshots",
+            .max_snapshots = 5,
+            .snapshot_interval_seconds = 300,
+        };
+        try db.enableSnapshots(snapshot_config);
+
+        static_alloc.transitionToStatic();
+
+        std.debug.print("Creating snapshot with test data...\n", .{});
+
+        // Fill database
+        var i: u64 = 0;
+        while (i < 10_000) : (i += 1) {
+            try db.write(i, "snapshot_recovery_test_data");
+        }
+
+        // Create snapshot
+        try db.createSnapshot();
+    }
+
+    // Now benchmark snapshot-only recovery
+    const snapshot_sizes = [_]u64{ 5_000, 10_000, 15_000, 25_000 };
+
+    for (snapshot_sizes) |capacity| {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+        var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = capacity });
+        defer {
+            static_alloc.transitionToDeinit();
+            db.deinit();
+        }
+
+        const snapshot_config = snapshot.SnapshotManager.Config{
+            .snapshot_dir = "/tmp/recovery_snapshots",
+            .max_snapshots = 5,
+            .snapshot_interval_seconds = 300,
+        };
+        try db.enableSnapshots(snapshot_config);
+
+        static_alloc.transitionToStatic();
+
+        const recovery_start = std.time.nanoTimestamp();
+        db.performRecovery("/tmp/nonexistent.wal") catch {}; // WAL doesn't exist, only snapshot
+        const recovery_end = std.time.nanoTimestamp();
+
+        const recovery_time_ms = @as(f64, @floatFromInt(@as(u64, @intCast(recovery_end - recovery_start)))) / 1_000_000.0;
+        const stats = db.getStats();
+
+        std.debug.print("  {}K capacity: {d:.1} ms ({} records recovered)\n", .{ capacity / 1000, recovery_time_ms, stats.used_capacity });
+    }
+}
+
+fn benchmarkSnapshotPlusWALRecovery(allocator: std.mem.Allocator) !void {
+    std.debug.print("\n--- Benchmark 3: Snapshot + WAL Recovery ---\n", .{});
+
+    // Create database with snapshot + additional WAL data
+    {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+        var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = 20_000 });
+        defer {
+            static_alloc.transitionToDeinit();
+            db.deinit();
+        }
+
+        const wal_config = wal.DurabilityManager.Config{
+            .wal_path = "/tmp/recovery_test.wal",
+            .max_threads = 4,
+            .ring_buffer_size = 2048,
+            .batch_buffer_count = 8,
+            .io_uring_entries = 32,
+        };
+        try db.enableDurability(wal_config);
+
+        const snapshot_config = snapshot.SnapshotManager.Config{
+            .snapshot_dir = "/tmp/recovery_snapshots",
+            .max_snapshots = 5,
+            .snapshot_interval_seconds = 300,
+        };
+        try db.enableSnapshots(snapshot_config);
+
+        static_alloc.transitionToStatic();
+
+        std.debug.print("Creating snapshot + WAL data scenario...\n", .{});
+
+        // Fill database up to snapshot point
+        var i: u64 = 0;
+        while (i < 8_000) : (i += 1) {
+            try db.write(i, "pre_snapshot_data");
+        }
+
+        // Create snapshot
+        try db.createSnapshot();
+
+        // Add more data after snapshot (will be in WAL)
+        while (i < 12_000) : (i += 1) {
+            try db.write(i, "post_snapshot_wal_data");
+        }
+
+        // Wait for WAL
+        std.time.sleep(100_000_000);
+    }
+
+    // Benchmark combined recovery
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+    var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = 20_000 });
+    defer {
+        static_alloc.transitionToDeinit();
+        db.deinit();
+    }
+
+    const snapshot_config = snapshot.SnapshotManager.Config{
+        .snapshot_dir = "/tmp/recovery_snapshots",
+        .max_snapshots = 5,
+        .snapshot_interval_seconds = 300,
+    };
+    try db.enableSnapshots(snapshot_config);
+
+    static_alloc.transitionToStatic();
+
+    const recovery_start = std.time.nanoTimestamp();
+    try db.performRecovery("/tmp/recovery_test.wal");
+    const recovery_end = std.time.nanoTimestamp();
+
+    const recovery_time_ms = @as(f64, @floatFromInt(@as(u64, @intCast(recovery_end - recovery_start)))) / 1_000_000.0;
+    const stats = db.getStats();
+
+    std.debug.print("  Combined Recovery: {d:.1} ms ({} records total)\n", .{ recovery_time_ms, stats.used_capacity });
+}
+
+fn benchmarkWALWriteVerification(allocator: std.mem.Allocator) !void {
+    std.debug.print("\n--- Benchmark 4: WAL Write Verification ---\n", .{});
+
+    std.debug.print("Testing WAL write functionality...\n", .{});
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var static_alloc = static_allocator.StaticAllocator.init(arena.allocator());
+
+    var db = try wild.WILD.init(static_alloc.allocator(), wild.WILD.Config{ .target_capacity = 5_000 });
+    defer {
+        static_alloc.transitionToDeinit();
+        db.deinit();
+    }
+
+    const wal_config = wal.DurabilityManager.Config{
+        .wal_path = "/tmp/wal_verification.wal",
+        .max_threads = 2,
+        .ring_buffer_size = 512,
+        .batch_buffer_count = 4,
+        .io_uring_entries = 16,
+    };
+    try db.enableDurability(wal_config);
+
+    static_alloc.transitionToStatic();
+
+    // Write some test data
+    std.debug.print("Writing test data to trigger WAL writes...\n", .{});
+
+    var i: u64 = 0;
+    while (i < 1000) : (i += 1) {
+        try db.write(i, "wal_verification_test_data_payload");
+
+        // Check stats every 100 writes
+        if (i % 100 == 0) {
+            if (db.getDurabilityStatsNoAlloc()) |stats| {
+                std.debug.print("  After {} writes: {} batches, {} entries, {} dropped\n", .{ i + 1, stats.batches_written, stats.total_entries_written, stats.entries_dropped });
+            }
+        }
+    }
+
+    // Final wait and stats
+    std.debug.print("Waiting for final WAL flush...\n", .{});
+    std.time.sleep(200_000_000); // 200ms
+
+    if (db.getDurabilityStatsNoAlloc()) |final_stats| {
+        std.debug.print("\nFinal WAL Stats:\n", .{});
+        std.debug.print("  Batches Written:     {}\n", .{final_stats.batches_written});
+        std.debug.print("  Entries Written:     {}\n", .{final_stats.total_entries_written});
+        std.debug.print("  Entries Dropped:     {}\n", .{final_stats.entries_dropped});
+        std.debug.print("  WAL Size:            {d:.2} KB\n", .{@as(f64, @floatFromInt(final_stats.wal_size_bytes)) / 1024.0});
+        std.debug.print("  I/O Errors:          {}\n", .{final_stats.io_errors});
+        std.debug.print("  Completed I/Os:      {}\n", .{final_stats.completed_ios});
+    }
+
+    // Check if file actually exists on disk
+    const wal_file = std.fs.cwd().openFile("/tmp/wal_verification.wal", .{}) catch |err| {
+        std.debug.print("❌ WAL file verification failed: {}\n", .{err});
+        return;
+    };
+    defer wal_file.close();
+
+    const actual_size = try wal_file.getEndPos();
+    std.debug.print("✓ WAL file on disk: {} bytes\n", .{actual_size});
+
+    // Read first few bytes to verify content
+    var buffer: [64]u8 = undefined;
+    try wal_file.seekTo(0);
+    const bytes_read = try wal_file.readAll(&buffer);
+    std.debug.print("✓ WAL file readable: {} bytes read\n", .{bytes_read});
+}

--- a/src/flat_hash_storage.zig
+++ b/src/flat_hash_storage.zig
@@ -3,8 +3,8 @@ const cache_topology = @import("cache_topology.zig");
 
 // Cache-line-aligned record that fits exactly in one cache line
 pub const CacheLineRecord = extern struct {
-    metadata: u32, // 4 bytes: 1 bit valid flag + 6 bits length + 25 bits reserved (check first)
-    key: u64, // 8 bytes (check second for key comparison)
+    key: u64, // 8 bytes (check first for key comparison)
+    metadata: u32, // 4 bytes: 1 bit valid flag + 6 bits length + 25 bits reserved
     data: [52]u8, // 52 bytes data payload (accessed last)
     // Total: 64 bytes = exactly 1 cache line
 
@@ -72,6 +72,9 @@ pub fn hashKey(key: anytype) u64 {
     }
 }
 
+// Forward declaration for optional WAL
+const wal = @import("wal.zig");
+
 // Flat hash table with linear probing - no artificial capacity limits
 pub const FlatHashStorage = struct {
     const Self = @This();
@@ -81,6 +84,9 @@ pub const FlatHashStorage = struct {
     count: u32,
     topology: *const cache_topology.CacheTopology,
     allocator: std.mem.Allocator,
+
+    // Optional WAL for durability - null means no durability
+    durability_manager: ?*wal.DurabilityManager,
 
     // NUMA placement hints (for future optimization)
     numa_domains: u32,
@@ -118,6 +124,7 @@ pub const FlatHashStorage = struct {
             .count = 0,
             .topology = topology,
             .allocator = allocator,
+            .durability_manager = null, // Initially no WAL
             .numa_domains = numa_domains,
             .records_per_domain = records_per_domain,
         };
@@ -197,8 +204,15 @@ pub const FlatHashStorage = struct {
         const old_record = &self.records[pos];
         const is_update = old_record.isValid() and old_record.key == key;
 
-        // Create new record
+        // Critical path: update cache line (maintains 42ns performance)
         self.records[pos] = try CacheLineRecord.init(key, data);
+
+        // Always-async durability: never blocks
+        if (self.durability_manager) |dur_mgr| {
+            _ = dur_mgr.appendAsync(&self.records[pos]);
+            // Note: We ignore the return value to never block
+            // If WAL ring is full, the entry is dropped but write succeeds
+        }
 
         // Update count only for new insertions
         if (!is_update) {
@@ -223,6 +237,16 @@ pub const FlatHashStorage = struct {
         // Zero out all records with memset - much faster than looping
         @memset(std.mem.sliceAsBytes(self.records), 0);
         self.count = 0;
+    }
+
+    // Enable durability by associating with a WAL manager
+    pub fn enableDurability(self: *Self, durability_manager: *wal.DurabilityManager) void {
+        self.durability_manager = durability_manager;
+    }
+
+    // Disable durability
+    pub fn disableDurability(self: *Self) void {
+        self.durability_manager = null;
     }
 
     pub fn getStats(self: *const Self) StorageStats {

--- a/src/metrics.zig
+++ b/src/metrics.zig
@@ -1,0 +1,357 @@
+const std = @import("std");
+const wild = @import("wild.zig");
+
+// Performance metrics collection and monitoring for WILD database
+// Provides real-time performance tracking without impacting hot path
+
+pub const MetricsCollector = struct {
+    const Self = @This();
+
+    // Core operation metrics
+    write_count: std.atomic.Value(u64),
+    read_count: std.atomic.Value(u64),
+    delete_count: std.atomic.Value(u64),
+
+    // Timing metrics (nanoseconds) - using lock-free circular buffers
+    write_times: CircularBuffer,
+    read_times: CircularBuffer,
+
+    // Error tracking
+    table_full_count: std.atomic.Value(u64),
+    key_not_found_count: std.atomic.Value(u64),
+
+    // Cache performance metrics
+    cache_hit_count: std.atomic.Value(u64),
+    cache_miss_count: std.atomic.Value(u64),
+
+    // System resource metrics
+    memory_usage_bytes: std.atomic.Value(u64),
+    load_factor_x1000: std.atomic.Value(u32), // Load factor * 1000 for precision
+
+    // Performance snapshot for reporting
+    last_snapshot_time: std.atomic.Value(u64),
+    snapshot_interval_ns: u64,
+
+    allocator: std.mem.Allocator,
+
+    pub const Config = struct {
+        buffer_size: u32 = 1000, // Number of recent timings to track
+        snapshot_interval_seconds: u64 = 60, // How often to take performance snapshots
+    };
+
+    pub const PerformanceSnapshot = struct {
+        // Counts
+        total_writes: u64,
+        total_reads: u64,
+        total_deletes: u64,
+        total_errors: u64,
+
+        // Performance (nanoseconds)
+        avg_write_latency_ns: f64,
+        avg_read_latency_ns: f64,
+        min_write_latency_ns: u64,
+        max_write_latency_ns: u64,
+        p99_write_latency_ns: u64,
+
+        // Throughput (operations per second)
+        writes_per_sec: f64,
+        reads_per_sec: f64,
+        total_ops_per_sec: f64,
+
+        // Resource usage
+        memory_usage_mb: f64,
+        load_factor: f32,
+        cache_hit_rate: f32,
+
+        // Time range
+        measurement_duration_sec: f64,
+        timestamp: u64,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, config: Config) !Self {
+        return Self{
+            .write_count = std.atomic.Value(u64).init(0),
+            .read_count = std.atomic.Value(u64).init(0),
+            .delete_count = std.atomic.Value(u64).init(0),
+
+            .write_times = try CircularBuffer.init(allocator, config.buffer_size),
+            .read_times = try CircularBuffer.init(allocator, config.buffer_size),
+
+            .table_full_count = std.atomic.Value(u64).init(0),
+            .key_not_found_count = std.atomic.Value(u64).init(0),
+
+            .cache_hit_count = std.atomic.Value(u64).init(0),
+            .cache_miss_count = std.atomic.Value(u64).init(0),
+
+            .memory_usage_bytes = std.atomic.Value(u64).init(0),
+            .load_factor_x1000 = std.atomic.Value(u32).init(0),
+
+            .last_snapshot_time = std.atomic.Value(u64).init(@as(u64, @intCast(std.time.nanoTimestamp()))),
+            .snapshot_interval_ns = config.snapshot_interval_seconds * 1_000_000_000,
+
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.write_times.deinit();
+        self.read_times.deinit();
+    }
+
+    // Hot path metrics - designed for minimal overhead
+    pub inline fn recordWrite(self: *Self, latency_ns: u64) void {
+        _ = self.write_count.fetchAdd(1, .monotonic);
+        self.write_times.add(latency_ns);
+    }
+
+    pub inline fn recordRead(self: *Self, latency_ns: u64, hit: bool) void {
+        _ = self.read_count.fetchAdd(1, .monotonic);
+        self.read_times.add(latency_ns);
+
+        if (hit) {
+            _ = self.cache_hit_count.fetchAdd(1, .monotonic);
+        } else {
+            _ = self.cache_miss_count.fetchAdd(1, .monotonic);
+        }
+    }
+
+    pub inline fn recordDelete(self: *Self) void {
+        _ = self.delete_count.fetchAdd(1, .monotonic);
+    }
+
+    pub inline fn recordError(self: *Self, error_type: ErrorType) void {
+        switch (error_type) {
+            .TableFull => _ = self.table_full_count.fetchAdd(1, .monotonic),
+            .KeyNotFound => _ = self.key_not_found_count.fetchAdd(1, .monotonic),
+        }
+    }
+
+    // Update system metrics (called periodically, not on hot path)
+    pub fn updateSystemMetrics(self: *Self, db_stats: wild.WILD.Stats) void {
+        const memory_bytes = @as(u64, db_stats.total_capacity) * 64; // 64 bytes per record
+        self.memory_usage_bytes.store(memory_bytes, .monotonic);
+
+        const load_factor_scaled = @as(u32, @intFromFloat(db_stats.load_factor * 1000.0));
+        self.load_factor_x1000.store(load_factor_scaled, .monotonic);
+    }
+
+    // Check if it's time to take a performance snapshot
+    pub fn shouldTakeSnapshot(self: *const Self) bool {
+        const now = @as(u64, @intCast(std.time.nanoTimestamp()));
+        const last_snapshot = self.last_snapshot_time.load(.monotonic);
+        return (now - last_snapshot) >= self.snapshot_interval_ns;
+    }
+
+    // Take a performance snapshot (for reporting/monitoring)
+    pub fn takeSnapshot(self: *Self) PerformanceSnapshot {
+        const now = @as(u64, @intCast(std.time.nanoTimestamp()));
+        const last_snapshot = self.last_snapshot_time.swap(now, .monotonic);
+        const duration_ns = now - last_snapshot;
+        const duration_sec = @as(f64, @floatFromInt(duration_ns)) / 1_000_000_000.0;
+
+        // Get current counts
+        const writes = self.write_count.load(.monotonic);
+        const reads = self.read_count.load(.monotonic);
+        const deletes = self.delete_count.load(.monotonic);
+        const table_full_errors = self.table_full_count.load(.monotonic);
+        const key_not_found_errors = self.key_not_found_count.load(.monotonic);
+
+        // Calculate cache hit rate
+        const cache_hits = self.cache_hit_count.load(.monotonic);
+        const cache_misses = self.cache_miss_count.load(.monotonic);
+        const total_cache_ops = cache_hits + cache_misses;
+        const cache_hit_rate = if (total_cache_ops > 0)
+            @as(f32, @floatFromInt(cache_hits)) / @as(f32, @floatFromInt(total_cache_ops))
+        else
+            0.0;
+
+        // Analyze timing data
+        const write_stats = self.write_times.analyze();
+        const read_stats = self.read_times.analyze();
+
+        // Calculate throughput
+        const writes_per_sec = if (duration_sec > 0) @as(f64, @floatFromInt(writes)) / duration_sec else 0;
+        const reads_per_sec = if (duration_sec > 0) @as(f64, @floatFromInt(reads)) / duration_sec else 0;
+        const total_ops_per_sec = writes_per_sec + reads_per_sec;
+
+        // Get resource metrics
+        const memory_bytes = self.memory_usage_bytes.load(.monotonic);
+        const memory_mb = @as(f64, @floatFromInt(memory_bytes)) / (1024.0 * 1024.0);
+        const load_factor = @as(f32, @floatFromInt(self.load_factor_x1000.load(.monotonic))) / 1000.0;
+
+        return PerformanceSnapshot{
+            .total_writes = writes,
+            .total_reads = reads,
+            .total_deletes = deletes,
+            .total_errors = table_full_errors + key_not_found_errors,
+
+            .avg_write_latency_ns = write_stats.average,
+            .avg_read_latency_ns = read_stats.average,
+            .min_write_latency_ns = write_stats.minimum,
+            .max_write_latency_ns = write_stats.maximum,
+            .p99_write_latency_ns = write_stats.p99,
+
+            .writes_per_sec = writes_per_sec,
+            .reads_per_sec = reads_per_sec,
+            .total_ops_per_sec = total_ops_per_sec,
+
+            .memory_usage_mb = memory_mb,
+            .load_factor = load_factor,
+            .cache_hit_rate = cache_hit_rate,
+
+            .measurement_duration_sec = duration_sec,
+            .timestamp = now,
+        };
+    }
+
+    // Print human-readable performance report
+    pub fn printReport(snapshot: PerformanceSnapshot) void {
+        const timestamp = @as(i64, @intCast(snapshot.timestamp));
+        std.debug.print("\n=== WILD Performance Report ===\n", .{});
+        std.debug.print("Timestamp: {} (duration: {d:.1}s)\n", .{ timestamp, snapshot.measurement_duration_sec });
+
+        std.debug.print("\nOperation Counts:\n", .{});
+        std.debug.print("  Writes:       {}\n", .{snapshot.total_writes});
+        std.debug.print("  Reads:        {}\n", .{snapshot.total_reads});
+        std.debug.print("  Deletes:      {}\n", .{snapshot.total_deletes});
+        std.debug.print("  Errors:       {}\n", .{snapshot.total_errors});
+
+        std.debug.print("\nLatency (nanoseconds):\n", .{});
+        std.debug.print("  Avg Write:    {d:.1} ns\n", .{snapshot.avg_write_latency_ns});
+        std.debug.print("  Avg Read:     {d:.1} ns\n", .{snapshot.avg_read_latency_ns});
+        std.debug.print("  Min Write:    {} ns\n", .{snapshot.min_write_latency_ns});
+        std.debug.print("  Max Write:    {} ns\n", .{snapshot.max_write_latency_ns});
+        std.debug.print("  P99 Write:    {} ns\n", .{snapshot.p99_write_latency_ns});
+
+        std.debug.print("\nThroughput:\n", .{});
+        std.debug.print("  Writes/sec:   {d:.0}\n", .{snapshot.writes_per_sec});
+        std.debug.print("  Reads/sec:    {d:.0}\n", .{snapshot.reads_per_sec});
+        std.debug.print("  Total ops/sec:{d:.0}\n", .{snapshot.total_ops_per_sec});
+
+        std.debug.print("\nResource Usage:\n", .{});
+        std.debug.print("  Memory:       {d:.1} MB\n", .{snapshot.memory_usage_mb});
+        std.debug.print("  Load Factor:  {d:.1}%\n", .{snapshot.load_factor * 100});
+        std.debug.print("  Cache Hit:    {d:.1}%\n", .{snapshot.cache_hit_rate * 100});
+
+        // Performance assessment
+        std.debug.print("\nPerformance Assessment:\n", .{});
+        if (snapshot.avg_write_latency_ns <= 42.0) {
+            std.debug.print("  Write Latency: ✅ EXCELLENT (≤42ns target)\n", .{});
+        } else if (snapshot.avg_write_latency_ns <= 100.0) {
+            std.debug.print("  Write Latency: ✅ GOOD (≤100ns)\n", .{});
+        } else {
+            std.debug.print("  Write Latency: ⚠️ DEGRADED (>100ns)\n", .{});
+        }
+
+        if (snapshot.cache_hit_rate >= 0.90) {
+            std.debug.print("  Cache Efficiency: ✅ EXCELLENT (≥90%)\n", .{});
+        } else if (snapshot.cache_hit_rate >= 0.70) {
+            std.debug.print("  Cache Efficiency: ✅ GOOD (≥70%)\n", .{});
+        } else {
+            std.debug.print("  Cache Efficiency: ⚠️ LOW (<70%)\n", .{});
+        }
+
+        std.debug.print("================================\n", .{});
+    }
+
+    pub const ErrorType = enum {
+        TableFull,
+        KeyNotFound,
+    };
+};
+
+// Lock-free circular buffer for tracking recent latency measurements
+const CircularBuffer = struct {
+    const Self = @This();
+
+    buffer: []u64,
+    write_index: std.atomic.Value(u32),
+    size: u32,
+    allocator: std.mem.Allocator,
+
+    const Stats = struct {
+        average: f64,
+        minimum: u64,
+        maximum: u64,
+        p99: u64,
+        count: u32,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, size: u32) !Self {
+        const buffer = try allocator.alloc(u64, size);
+        @memset(buffer, 0);
+
+        return Self{
+            .buffer = buffer,
+            .write_index = std.atomic.Value(u32).init(0),
+            .size = size,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.allocator.free(self.buffer);
+    }
+
+    // Add a new measurement (lock-free)
+    pub inline fn add(self: *Self, value: u64) void {
+        const index = self.write_index.fetchAdd(1, .monotonic) % self.size;
+        self.buffer[index] = value;
+    }
+
+    // Analyze current buffer contents (snapshot-based, safe for concurrent access)
+    pub fn analyze(self: *const Self) Stats {
+        // Create a snapshot of current buffer state
+        var snapshot: [1000]u64 = undefined; // Max buffer size
+        const actual_size = @min(self.size, 1000);
+
+        // Copy current buffer contents (may have some inconsistency but that's ok for metrics)
+        for (0..actual_size) |i| {
+            snapshot[i] = self.buffer[i];
+        }
+
+        // Filter out uninitialized values (zeros)
+        var valid_count: u32 = 0;
+        for (0..actual_size) |i| {
+            if (snapshot[i] > 0) {
+                snapshot[valid_count] = snapshot[i];
+                valid_count += 1;
+            }
+        }
+
+        if (valid_count == 0) {
+            return Stats{
+                .average = 0,
+                .minimum = 0,
+                .maximum = 0,
+                .p99 = 0,
+                .count = 0,
+            };
+        }
+
+        // Sort for percentiles
+        std.mem.sort(u64, snapshot[0..valid_count], {}, std.sort.asc(u64));
+
+        // Calculate statistics
+        var sum: u64 = 0;
+        for (snapshot[0..valid_count]) |value| {
+            sum += value;
+        }
+
+        const average = @as(f64, @floatFromInt(sum)) / @as(f64, @floatFromInt(valid_count));
+        const minimum = snapshot[0];
+        const maximum = snapshot[valid_count - 1];
+
+        // P99 calculation
+        const p99_index = (valid_count * 99) / 100;
+        const p99 = if (p99_index < valid_count) snapshot[p99_index] else maximum;
+
+        return Stats{
+            .average = average,
+            .minimum = minimum,
+            .maximum = maximum,
+            .p99 = p99,
+            .count = valid_count,
+        };
+    }
+};

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1,0 +1,660 @@
+const std = @import("std");
+const flat_hash_storage = @import("flat_hash_storage.zig");
+const wal = @import("wal.zig");
+
+// Snapshot file format for WILD database recovery
+// Design: Memory-mapped file with header + flat array of cache-line records
+// Compatible with zero-copy loading and efficient iteration
+
+// Snapshot file header - fixed size for memory mapping alignment
+pub const SnapshotHeader = extern struct {
+    // Magic bytes for format validation
+    magic: [8]u8 = [8]u8{ 'W', 'I', 'L', 'D', 'S', 'N', 'A', 'P' },
+
+    // Version for format evolution
+    version: u32 = 1,
+
+    // Snapshot metadata
+    snapshot_id: u64,
+    creation_timestamp: u64, // Unix timestamp in nanoseconds
+    wal_position: u64, // WAL offset at time of snapshot
+
+    // Database state at snapshot time
+    total_records: u64,
+    total_capacity: u64,
+    load_factor_x1000: u32, // Load factor * 1000 for precision
+
+    // File layout information
+    records_offset: u64, // Offset to start of records array
+    records_size_bytes: u64, // Total size of records section
+
+    // Checksums for integrity
+    header_checksum: u32, // CRC32 of header (excluding this field)
+    records_checksum: u32, // CRC32 of all records
+
+    // Reserved for future use (adjusted for padding)
+    reserved: [40]u8 = std.mem.zeroes([40]u8),
+
+    const Self = @This();
+
+    comptime {
+        // Ensure header is cache-line aligned
+        std.debug.assert(@sizeOf(SnapshotHeader) == 128);
+    }
+
+    pub fn init(snapshot_id: u64, wal_position: u64, storage_stats: flat_hash_storage.StorageStats) Self {
+        return Self{
+            .snapshot_id = snapshot_id,
+            .creation_timestamp = @as(u64, @intCast(std.time.nanoTimestamp())),
+            .wal_position = wal_position,
+            .total_records = storage_stats.total_count,
+            .total_capacity = storage_stats.total_capacity,
+            .load_factor_x1000 = @intFromFloat(storage_stats.load_factor * 1000.0),
+            .records_offset = @sizeOf(SnapshotHeader),
+            .records_size_bytes = storage_stats.total_capacity * @sizeOf(flat_hash_storage.CacheLineRecord),
+            .header_checksum = 0, // Will be calculated after creation
+            .records_checksum = 0, // Will be calculated after writing records
+        };
+    }
+
+    pub fn calculateHeaderChecksum(self: *Self) void {
+        // Temporarily zero the checksum field
+        const old_checksum = self.header_checksum;
+        self.header_checksum = 0;
+
+        // Calculate CRC32 of the header
+        const header_bytes = std.mem.asBytes(self);
+        self.header_checksum = std.hash.Crc32.hash(header_bytes);
+
+        // Restore if calculation failed (shouldn't happen)
+        if (self.header_checksum == 0) {
+            self.header_checksum = old_checksum;
+        }
+    }
+
+    pub fn validateHeader(self: *const Self) bool {
+        // Check magic bytes
+        if (!std.mem.eql(u8, &self.magic, &[8]u8{ 'W', 'I', 'L', 'D', 'S', 'N', 'A', 'P' })) {
+            return false;
+        }
+
+        // Check version
+        if (self.version != 1) {
+            return false;
+        }
+
+        // Validate checksum
+        var header_copy = self.*;
+        const stored_checksum = header_copy.header_checksum;
+        header_copy.calculateHeaderChecksum();
+
+        return header_copy.header_checksum == stored_checksum;
+    }
+};
+
+// Memory-mapped snapshot file for fast recovery
+pub const SnapshotFile = struct {
+    file: std.fs.File,
+    mapped_memory: []align(std.heap.page_size_min) u8,
+    header: *SnapshotHeader,
+    records: []flat_hash_storage.CacheLineRecord,
+
+    const Self = @This();
+
+    // Create a new snapshot from current database state
+    pub fn create(file_path: []const u8, storage: *const flat_hash_storage.FlatHashStorage, current_wal_position: u64) !Self {
+        const storage_stats = storage.getStats();
+
+        // Calculate total file size (header + records, page-aligned)
+        const records_size = storage_stats.total_capacity * @sizeOf(flat_hash_storage.CacheLineRecord);
+        const total_size = @sizeOf(SnapshotHeader) + records_size;
+        const aligned_size = std.mem.alignForward(usize, total_size, std.heap.page_size_min);
+
+        // Create snapshot file
+        const file = try std.fs.cwd().createFile(file_path, .{ .read = true, .truncate = true });
+        try file.setEndPos(aligned_size);
+
+        // Memory map the file
+        const mapped_memory = try std.posix.mmap(
+            null,
+            aligned_size,
+            std.posix.PROT.READ | std.posix.PROT.WRITE,
+            .{ .TYPE = .SHARED },
+            file.handle,
+            0,
+        );
+
+        // Initialize header
+        const header = @as(*SnapshotHeader, @ptrCast(@alignCast(mapped_memory.ptr)));
+        header.* = SnapshotHeader.init(@as(u64, @intCast(std.time.milliTimestamp())), // Use timestamp as snapshot ID
+            current_wal_position, storage_stats);
+
+        // Get records array view
+        const records_ptr = @as([*]flat_hash_storage.CacheLineRecord, @ptrCast(@alignCast(mapped_memory.ptr + @sizeOf(SnapshotHeader))));
+        const records = records_ptr[0..storage_stats.total_capacity];
+
+        // Copy all records from storage (atomic snapshot)
+        storage.copyAllRecords(records);
+
+        // Calculate records checksum
+        const records_bytes = std.mem.sliceAsBytes(records);
+        header.records_checksum = std.hash.Crc32.hash(records_bytes);
+
+        // Calculate header checksum (must be last)
+        header.calculateHeaderChecksum();
+
+        // Ensure data is written to disk
+        try std.posix.msync(mapped_memory, std.posix.MSF.SYNC);
+
+        std.debug.print("Created snapshot: {} records, {} bytes, WAL position {}\n", .{ storage_stats.total_count, aligned_size, current_wal_position });
+
+        return Self{
+            .file = file,
+            .mapped_memory = mapped_memory,
+            .header = header,
+            .records = records,
+        };
+    }
+
+    // Load existing snapshot from disk
+    pub fn load(file_path: []const u8) !Self {
+        const file = try std.fs.cwd().openFile(file_path, .{ .mode = .read_only });
+        const file_size = try file.getEndPos();
+
+        // Memory map the file
+        const mapped_memory = try std.posix.mmap(
+            null,
+            file_size,
+            std.posix.PROT.READ,
+            .{ .TYPE = .SHARED },
+            file.handle,
+            0,
+        );
+
+        // Validate header
+        const header = @as(*SnapshotHeader, @ptrCast(@alignCast(mapped_memory.ptr)));
+        if (!header.validateHeader()) {
+            std.posix.munmap(mapped_memory);
+            file.close();
+            return error.InvalidSnapshotHeader;
+        }
+
+        // Get records array view
+        const records_ptr = @as([*]flat_hash_storage.CacheLineRecord, @ptrCast(@alignCast(mapped_memory.ptr + header.records_offset)));
+        const records = records_ptr[0..header.total_capacity];
+
+        // Validate records checksum
+        const records_bytes = std.mem.sliceAsBytes(records);
+        const calculated_checksum = std.hash.Crc32.hash(records_bytes);
+        if (calculated_checksum != header.records_checksum) {
+            std.posix.munmap(mapped_memory);
+            file.close();
+            return error.InvalidSnapshotChecksum;
+        }
+
+        std.debug.print("Loaded snapshot: {} records, {} bytes, WAL position {}\n", .{ header.total_records, file_size, header.wal_position });
+
+        return Self{
+            .file = file,
+            .mapped_memory = mapped_memory,
+            .header = header,
+            .records = records,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        std.posix.munmap(self.mapped_memory);
+        self.file.close();
+    }
+
+    // Get snapshot metadata
+    pub fn getMetadata(self: *const Self) struct {
+        snapshot_id: u64,
+        creation_timestamp: u64,
+        wal_position: u64,
+        total_records: u64,
+        total_capacity: u64,
+        load_factor: f32,
+    } {
+        return .{
+            .snapshot_id = self.header.snapshot_id,
+            .creation_timestamp = self.header.creation_timestamp,
+            .wal_position = self.header.wal_position,
+            .total_records = self.header.total_records,
+            .total_capacity = self.header.total_capacity,
+            .load_factor = @as(f32, @floatFromInt(self.header.load_factor_x1000)) / 1000.0,
+        };
+    }
+
+    // Restore database state from this snapshot
+    pub fn restoreToStorage(self: *const Self, storage: *flat_hash_storage.FlatHashStorage) !void {
+        // Verify capacities match
+        const storage_stats = storage.getStats();
+        if (storage_stats.total_capacity != self.header.total_capacity) {
+            return error.CapacityMismatch;
+        }
+
+        // Clear current storage
+        storage.clear();
+
+        // Copy all valid records from snapshot
+        for (self.records) |*record| {
+            if (record.isValid()) {
+                try storage.restoreRecord(record);
+            }
+        }
+
+        std.debug.print("Restored {} records from snapshot\n", .{self.header.total_records});
+    }
+};
+
+// Snapshot manager for coordinating snapshot creation and WAL integration
+pub const SnapshotManager = struct {
+    snapshot_dir: []const u8,
+    max_snapshots: u32,
+    snapshot_interval_seconds: u64,
+
+    // Current snapshot state
+    current_snapshot: ?SnapshotFile,
+    last_snapshot_time: std.atomic.Value(u64),
+    snapshot_counter: std.atomic.Value(u64),
+
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub const Config = struct {
+        snapshot_dir: []const u8,
+        max_snapshots: u32 = 10,
+        snapshot_interval_seconds: u64 = 300, // 5 minutes
+    };
+
+    pub fn init(allocator: std.mem.Allocator, config: Config) !Self {
+        // Ensure snapshot directory exists
+        std.fs.cwd().makeDir(config.snapshot_dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return err,
+        };
+
+        return Self{
+            .snapshot_dir = try allocator.dupe(u8, config.snapshot_dir),
+            .max_snapshots = config.max_snapshots,
+            .snapshot_interval_seconds = config.snapshot_interval_seconds,
+            .current_snapshot = null,
+            .last_snapshot_time = std.atomic.Value(u64).init(0),
+            .snapshot_counter = std.atomic.Value(u64).init(0),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        if (self.current_snapshot) |*snapshot| {
+            snapshot.deinit();
+        }
+        self.allocator.free(self.snapshot_dir);
+    }
+
+    // Check if it's time to create a new snapshot
+    pub fn shouldCreateSnapshot(self: *const Self) bool {
+        const now = @as(u64, @intCast(std.time.timestamp()));
+        const last_snapshot = self.last_snapshot_time.load(.monotonic);
+        return (now - last_snapshot) >= self.snapshot_interval_seconds;
+    }
+
+    // Create a new snapshot of current database state
+    pub fn createSnapshot(self: *Self, storage: *const flat_hash_storage.FlatHashStorage, current_wal_position: u64) !void {
+        const snapshot_id = self.snapshot_counter.fetchAdd(1, .monotonic);
+
+        // Generate snapshot filename
+        var filename_buf: [256]u8 = undefined;
+        const filename = try std.fmt.bufPrint(filename_buf[0..], "{s}/wild_snapshot_{:0>10}.snap", .{ self.snapshot_dir, snapshot_id });
+
+        // Create new snapshot
+        const new_snapshot = try SnapshotFile.create(filename, storage, current_wal_position);
+
+        // Replace current snapshot
+        if (self.current_snapshot) |*old_snapshot| {
+            old_snapshot.deinit();
+        }
+        self.current_snapshot = new_snapshot;
+
+        // Update last snapshot time
+        self.last_snapshot_time.store(@as(u64, @intCast(std.time.timestamp())), .monotonic);
+
+        // TODO: Clean up old snapshots - requires allocation-free implementation
+        // self.cleanupOldSnapshots() catch |err| {
+        //     std.debug.print("Warning: Failed to cleanup old snapshots: {}\n", .{err});
+        // };
+    }
+
+    // Find and load the latest valid snapshot
+    pub fn loadLatestSnapshot(self: *Self) !?SnapshotFile {
+        var dir = try std.fs.cwd().openDir(self.snapshot_dir, .{ .iterate = true });
+        defer dir.close();
+
+        var iterator = dir.iterate();
+        var latest_snapshot_id: ?u64 = null; // Use optional to handle ID 0 correctly
+        var latest_filename_buf: [256]u8 = undefined; // Stack buffer to avoid allocation
+        var latest_filename_len: usize = 0;
+
+        // Find the latest snapshot file
+        while (try iterator.next()) |entry| {
+            if (entry.kind == .file and std.mem.endsWith(u8, entry.name, ".snap")) {
+                if (std.mem.startsWith(u8, entry.name, "wild_snapshot_")) {
+                    // Extract snapshot ID from filename
+                    const id_str = entry.name[14..24]; // "wild_snapshot_XXXXXXXXXX.snap"
+                    if (std.fmt.parseInt(u64, id_str, 10)) |snapshot_id| {
+                        if (latest_snapshot_id == null or snapshot_id > latest_snapshot_id.?) {
+                            latest_snapshot_id = snapshot_id;
+                            // Copy filename to stack buffer
+                            @memcpy(latest_filename_buf[0..entry.name.len], entry.name);
+                            latest_filename_len = entry.name.len;
+                        }
+                    } else |_| {
+                        // Invalid filename format, skip
+                        continue;
+                    }
+                }
+            }
+        }
+
+        if (latest_snapshot_id != null) {
+            const filename = latest_filename_buf[0..latest_filename_len];
+
+            var full_path_buf: [512]u8 = undefined;
+            const full_path = try std.fmt.bufPrint(full_path_buf[0..], "{s}/{s}", .{ self.snapshot_dir, filename });
+
+            return SnapshotFile.load(full_path) catch |err| {
+                std.debug.print("Failed to load snapshot {s}: {}\n", .{ filename, err });
+                return null;
+            };
+        }
+
+        return null;
+    }
+
+    // Clean up old snapshots, keeping only max_snapshots
+    fn cleanupOldSnapshots(self: *Self) !void {
+        var dir = try std.fs.cwd().openDir(self.snapshot_dir, .{ .iterate = true });
+        defer dir.close();
+
+        var snapshot_files = std.ArrayList(struct { name: []u8, id: u64 }).init(self.allocator);
+        defer {
+            for (snapshot_files.items) |item| {
+                self.allocator.free(item.name);
+            }
+            snapshot_files.deinit();
+        }
+
+        // Collect all snapshot files
+        var iterator = dir.iterate();
+        while (try iterator.next()) |entry| {
+            if (entry.kind == .file and std.mem.endsWith(u8, entry.name, ".snap")) {
+                if (std.mem.startsWith(u8, entry.name, "wild_snapshot_")) {
+                    const id_str = entry.name[14..24];
+                    if (std.fmt.parseInt(u64, id_str, 10)) |snapshot_id| {
+                        try snapshot_files.append(.{
+                            .name = try self.allocator.dupe(u8, entry.name),
+                            .id = snapshot_id,
+                        });
+                    } else |_| {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // Sort by ID (newest first)
+        std.mem.sort(@TypeOf(snapshot_files.items[0]), snapshot_files.items, {}, struct {
+            fn lessThan(_: void, a: @TypeOf(snapshot_files.items[0]), b: @TypeOf(snapshot_files.items[0])) bool {
+                return a.id > b.id;
+            }
+        }.lessThan);
+
+        // Delete old snapshots beyond max_snapshots
+        if (snapshot_files.items.len > self.max_snapshots) {
+            for (snapshot_files.items[self.max_snapshots..]) |item| {
+                dir.deleteFile(item.name) catch |err| {
+                    std.debug.print("Failed to delete old snapshot {s}: {}\n", .{ item.name, err });
+                };
+            }
+        }
+    }
+};
+
+// WAL replay functionality for point-in-time recovery
+pub const WALReplayer = struct {
+    wal_file_path: []const u8,
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, wal_file_path: []const u8) Self {
+        return Self{
+            .wal_file_path = wal_file_path,
+            .allocator = allocator,
+        };
+    }
+
+    // Replay WAL entries from a specific position to recover database state
+    pub fn replayFromPosition(self: *Self, storage: *flat_hash_storage.FlatHashStorage, start_position: u64, end_position: ?u64) !u64 {
+        const file = std.fs.cwd().openFile(self.wal_file_path, .{ .mode = .read_only }) catch |err| switch (err) {
+            error.FileNotFound => {
+                std.debug.print("WAL file not found, no replay needed\n", .{});
+                return start_position;
+            },
+            else => return err,
+        };
+        defer file.close();
+
+        const file_size = try file.getEndPos();
+        const actual_end_position = end_position orelse file_size;
+
+        if (start_position >= file_size) {
+            std.debug.print("WAL replay: start position {} beyond file size {}\n", .{ start_position, file_size });
+            return start_position;
+        }
+
+        std.debug.print("Replaying WAL from position {} to {} (file size: {})\n", .{ start_position, actual_end_position, file_size });
+
+        var current_position = start_position;
+        var entries_replayed: u64 = 0;
+
+        // Read and replay WAL batches
+        while (current_position + @sizeOf(wal.WALBatch) <= actual_end_position) {
+            // Read batch header first
+            try file.seekTo(current_position);
+
+            var batch: wal.WALBatch = undefined;
+            const bytes_read = try file.readAll(std.mem.asBytes(&batch));
+            if (bytes_read != @sizeOf(wal.WALBatch)) {
+                std.debug.print("WAL replay: incomplete batch at position {}\n", .{current_position});
+                break;
+            }
+
+            // Validate batch
+            if (batch.entry_count == 0 or batch.entry_count > wal.WALBatch.MAX_BATCH_ENTRIES) {
+                std.debug.print("WAL replay: invalid batch entry count {} at position {}\n", .{ batch.entry_count, current_position });
+                break;
+            }
+
+            // Replay entries in this batch
+            for (batch.entries[0..batch.entry_count]) |*entry| {
+                if (entry.isValid()) {
+                    // Convert WAL entry back to storage record format
+                    const key = entry.getKey();
+                    const data = entry.getData();
+
+                    // Apply the write operation
+                    storage.write(key, data) catch |err| {
+                        std.debug.print("WAL replay: failed to replay entry key={}: {}\n", .{ key, err });
+                        // Continue with other entries
+                        continue;
+                    };
+
+                    entries_replayed += 1;
+                }
+            }
+
+            current_position += @sizeOf(wal.WALBatch);
+        }
+
+        std.debug.print("WAL replay completed: {} entries replayed\n", .{entries_replayed});
+        return current_position;
+    }
+
+    // Get the current end position of the WAL file
+    pub fn getCurrentWALPosition(self: *Self) !u64 {
+        const file = std.fs.cwd().openFile(self.wal_file_path, .{ .mode = .read_only }) catch |err| switch (err) {
+            error.FileNotFound => return 0,
+            else => return err,
+        };
+        defer file.close();
+
+        return try file.getEndPos();
+    }
+
+    // Validate WAL integrity from a specific position
+    pub fn validateWAL(self: *Self, start_position: u64) !bool {
+        const file = std.fs.cwd().openFile(self.wal_file_path, .{ .mode = .read_only }) catch |err| switch (err) {
+            error.FileNotFound => return true, // No WAL file means nothing to validate
+            else => return err,
+        };
+        defer file.close();
+
+        const file_size = try file.getEndPos();
+        if (start_position >= file_size) {
+            return true; // Nothing to validate
+        }
+
+        var current_position = start_position;
+        var batches_validated: u32 = 0;
+
+        while (current_position + @sizeOf(wal.WALBatch) <= file_size) {
+            try file.seekTo(current_position);
+
+            var batch: wal.WALBatch = undefined;
+            const bytes_read = try file.readAll(std.mem.asBytes(&batch));
+            if (bytes_read != @sizeOf(wal.WALBatch)) {
+                std.debug.print("WAL validation: incomplete batch at position {}\n", .{current_position});
+                return false;
+            }
+
+            // Validate batch structure
+            if (batch.entry_count > wal.WALBatch.MAX_BATCH_ENTRIES) {
+                std.debug.print("WAL validation: invalid entry count {} at position {}\n", .{ batch.entry_count, current_position });
+                return false;
+            }
+
+            // Basic validation of entries
+            for (batch.entries[0..batch.entry_count]) |*entry| {
+                if (!entry.isValid()) {
+                    std.debug.print("WAL validation: invalid entry at batch position {}\n", .{current_position});
+                    return false;
+                }
+            }
+
+            current_position += @sizeOf(wal.WALBatch);
+            batches_validated += 1;
+        }
+
+        std.debug.print("WAL validation: {} batches validated successfully\n", .{batches_validated});
+        return true;
+    }
+};
+
+// Recovery coordinator that handles the complete crash recovery process
+pub const RecoveryCoordinator = struct {
+    snapshot_manager: *SnapshotManager,
+    wal_replayer: WALReplayer,
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, snapshot_manager: *SnapshotManager, wal_file_path: []const u8) Self {
+        return Self{
+            .snapshot_manager = snapshot_manager,
+            .wal_replayer = WALReplayer.init(allocator, wal_file_path),
+            .allocator = allocator,
+        };
+    }
+
+    // Perform complete crash recovery: load latest snapshot + replay WAL
+    pub fn performRecovery(self: *Self, storage: *flat_hash_storage.FlatHashStorage) !u64 {
+        std.debug.print("=== Starting WILD Database Recovery ===\n", .{});
+
+        // Step 1: Try to load the latest snapshot
+        var recovery_start_position: u64 = 0;
+
+        const maybe_snapshot = self.snapshot_manager.loadLatestSnapshot() catch |err| blk: {
+            std.debug.print("Error loading snapshot: {}, starting from empty database\n", .{err});
+            break :blk null; // Continue with null snapshot (empty database + full WAL replay)
+        };
+
+        if (maybe_snapshot) |snapshot| {
+            defer {
+                var mut_snapshot = snapshot;
+                mut_snapshot.deinit();
+            }
+
+            const metadata = snapshot.getMetadata();
+            std.debug.print("Found snapshot: ID={}, WAL position={}, {} records\n", .{ metadata.snapshot_id, metadata.wal_position, metadata.total_records });
+
+            // Restore from snapshot
+            try snapshot.restoreToStorage(storage);
+            recovery_start_position = metadata.wal_position;
+
+            std.debug.print("Restored database from snapshot\n", .{});
+        } else {
+            std.debug.print("No valid snapshot found, starting from empty database\n", .{});
+            storage.clear();
+            recovery_start_position = 0;
+        }
+
+        // Step 2: Validate WAL integrity
+        if (!try self.wal_replayer.validateWAL(recovery_start_position)) {
+            std.debug.print("WAL validation failed, recovery may be incomplete\n", .{});
+            return error.WALValidationFailed;
+        }
+
+        // Step 3: Replay WAL from snapshot position to current
+        const final_position = try self.wal_replayer.replayFromPosition(storage, recovery_start_position, null // Replay to end of WAL
+        );
+
+        const storage_stats = storage.getStats();
+        std.debug.print("=== Recovery Complete ===\n", .{});
+        std.debug.print("Final database state: {} records, {:.1}% load factor\n", .{ storage_stats.total_count, storage_stats.load_factor * 100 });
+        std.debug.print("WAL position: {}\n", .{final_position});
+
+        return final_position;
+    }
+
+    // Check if recovery is needed (detects unclean shutdown)
+    pub fn isRecoveryNeeded(self: *Self) !bool {
+        // Check if WAL file exists and has data
+        const current_wal_position = self.wal_replayer.getCurrentWALPosition() catch 0;
+        if (current_wal_position == 0) {
+            return false; // No WAL data, clean state
+        }
+
+        // Check if there's a snapshot and compare positions
+        const maybe_snapshot = self.snapshot_manager.loadLatestSnapshot() catch {
+            // Error loading snapshot, assume recovery needed if WAL has data
+            return current_wal_position > 0;
+        };
+
+        if (maybe_snapshot) |snapshot| {
+            defer {
+                var mut_snapshot = snapshot;
+                mut_snapshot.deinit();
+            }
+
+            const metadata = snapshot.getMetadata();
+            // Recovery needed if WAL has data beyond snapshot position
+            return current_wal_position > metadata.wal_position;
+        } else {
+            // No snapshot but WAL has data - recovery needed
+            return current_wal_position > 0;
+        }
+    }
+};

--- a/src/wal.zig
+++ b/src/wal.zig
@@ -1,0 +1,706 @@
+const std = @import("std");
+const flat_hash_storage = @import("flat_hash_storage.zig");
+
+// WAL entry - identical to CacheLineRecord for zero-copy
+pub const WALEntry = extern struct {
+    key: u64,
+    metadata: u32,
+    data: [52]u8,
+
+    const Self = @This();
+
+    comptime {
+        std.debug.assert(@sizeOf(WALEntry) == @sizeOf(flat_hash_storage.CacheLineRecord));
+    }
+
+    pub fn fromCacheLineRecord(record: *const flat_hash_storage.CacheLineRecord) WALEntry {
+        return WALEntry{
+            .key = record.key,
+            .metadata = record.metadata,
+            .data = record.data,
+        };
+    }
+
+    pub fn isValid(self: *const Self) bool {
+        return (self.metadata & flat_hash_storage.CacheLineRecord.VALID_FLAG) != 0;
+    }
+
+    pub fn getKey(self: *const Self) u64 {
+        return self.key;
+    }
+
+    pub fn getData(self: *const Self) []const u8 {
+        const len = @as(u32, @intCast(self.metadata & flat_hash_storage.CacheLineRecord.LENGTH_MASK));
+        return self.data[0..len];
+    }
+};
+
+// Batched WAL format - page-aligned blocks for efficient I/O
+pub const WALBatch = extern struct {
+    batch_id: u64,
+    view_number: u32,
+    entry_count: u16,
+    reserved: u16,
+    entries: [MAX_BATCH_ENTRIES]WALEntry,
+
+    // Calculate entries per page: (page_size - header_size) / entry_size
+    // Standard 4KB page: (4096 - 16) / 64 = 63 entries
+    pub const HEADER_SIZE = 16; // batch_id + view_number + entry_count + reserved
+    pub const MAX_BATCH_ENTRIES = (std.heap.page_size_min - HEADER_SIZE) / @sizeOf(WALEntry);
+
+    const Self = @This();
+
+    comptime {
+        // Ensure we fit within a page
+        std.debug.assert(@sizeOf(WALBatch) <= std.heap.page_size_min);
+    }
+
+    pub fn init(batch_id: u64, view_number: u32) Self {
+        return Self{
+            .batch_id = batch_id,
+            .view_number = view_number,
+            .entry_count = 0,
+            .reserved = 0,
+            .entries = std.mem.zeroes([MAX_BATCH_ENTRIES]WALEntry),
+        };
+    }
+
+    pub fn addEntry(self: *Self, entry: WALEntry) bool {
+        if (self.entry_count >= MAX_BATCH_ENTRIES) return false;
+
+        self.entries[self.entry_count] = entry;
+        self.entry_count += 1;
+        return true;
+    }
+
+    pub fn isFull(self: *const Self) bool {
+        return self.entry_count >= MAX_BATCH_ENTRIES;
+    }
+
+    pub fn isEmpty(self: *const Self) bool {
+        return self.entry_count == 0;
+    }
+};
+
+// Thread-local WAL ring buffer - all memory pre-allocated
+pub const ThreadLocalWAL = struct {
+    buffer: []WALEntry,
+    head: std.atomic.Value(u32),
+    tail: std.atomic.Value(u32),
+    capacity_mask: u32,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, capacity: u32) !Self {
+        // Ensure power-of-2 capacity for fast modulo
+        const actual_capacity = if (std.math.isPowerOfTwo(capacity))
+            capacity
+        else
+            std.math.floorPowerOfTwo(u32, capacity);
+
+        // Pre-allocate all ring buffer memory
+        const buffer = try allocator.alignedAlloc(WALEntry, 64, actual_capacity);
+
+        // Initialize all entries as invalid
+        for (buffer) |*entry| {
+            entry.* = std.mem.zeroes(WALEntry);
+        }
+
+        return Self{
+            .buffer = buffer,
+            .head = std.atomic.Value(u32).init(0),
+            .tail = std.atomic.Value(u32).init(0),
+            .capacity_mask = actual_capacity - 1,
+        };
+    }
+
+    pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+        allocator.free(self.buffer);
+    }
+
+    pub fn appendNonBlocking(self: *Self, entry: WALEntry) bool {
+        const current_tail = self.tail.load(.acquire);
+        const next_tail = (current_tail + 1) & self.capacity_mask;
+
+        // Check if ring buffer is full
+        if (next_tail == self.head.load(.acquire)) {
+            return false;
+        }
+
+        // Store entry and advance tail
+        self.buffer[current_tail] = entry;
+        self.tail.store(next_tail, .release);
+        return true;
+    }
+
+    pub fn drainBatch(self: *Self, batch: *WALBatch) u16 {
+        const current_head = self.head.load(.acquire);
+        const current_tail = self.tail.load(.acquire);
+
+        var count: u16 = 0;
+        var head = current_head;
+
+        while (head != current_tail and count < WALBatch.MAX_BATCH_ENTRIES) {
+            if (batch.addEntry(self.buffer[head])) {
+                head = (head + 1) & self.capacity_mask;
+                count += 1;
+            } else {
+                break;
+            }
+        }
+
+        if (count > 0) {
+            self.head.store(head, .release);
+        }
+
+        return count;
+    }
+
+    pub fn getUsage(self: *const Self) struct { used: u32, capacity: u32 } {
+        const head = self.head.load(.acquire);
+        const tail = self.tail.load(.acquire);
+        const used = if (tail >= head) tail - head else (self.capacity_mask + 1) - (head - tail);
+
+        return .{ .used = used, .capacity = self.capacity_mask + 1 };
+    }
+};
+
+// WAL completion following TigerBeetle patterns
+pub const WALCompletion = struct {
+    next: ?*WALCompletion,
+    batch: *WALBatch,
+    operation: Operation,
+    result: i32,
+
+    pub const Operation = enum {
+        write_batch,
+    };
+
+    pub fn init(batch: *WALBatch, operation: Operation) WALCompletion {
+        return WALCompletion{
+            .next = null,
+            .batch = batch,
+            .operation = operation,
+            .result = 0,
+        };
+    }
+};
+
+// io_uring-optimized durability manager - completion-based architecture
+pub const DurabilityManager = struct {
+    // WAL file management
+    wal_fd: std.posix.fd_t,
+    wal_offset: std.atomic.Value(u64),
+
+    // io_uring for async I/O
+    ring: std.os.linux.IoUring,
+
+    // Thread-local WAL rings - pre-allocated array
+    tls_wals: []ThreadLocalWAL,
+    current_tls_index: std.atomic.Value(u32),
+
+    // Pre-allocated batch buffers for durability thread (O_DIRECT aligned)
+    batch_buffers: []align(512) WALBatch,
+    batch_buffer_available: std.atomic.Value(u32), // Bitmask for available buffers
+
+    // Pre-allocated completion objects
+    completions: []WALCompletion,
+    completion_available: std.atomic.Value(u32), // Bitmask for available completions
+
+    // Completion queues following TigerBeetle pattern
+    unqueued: ?*WALCompletion,
+    completed: ?*WALCompletion,
+    awaiting: ?*WALCompletion,
+
+    // Queue locks
+    unqueued_lock: std.Thread.Mutex,
+    completed_lock: std.Thread.Mutex,
+    awaiting_lock: std.Thread.Mutex,
+
+    // Completion tracking
+    pending_ios: std.atomic.Value(u32),
+    completed_ios: std.atomic.Value(u64),
+
+    // Background thread
+    durability_thread: ?std.Thread,
+    should_stop: std.atomic.Value(bool),
+
+    // Statistics - all atomic for lock-free access
+    batches_written: std.atomic.Value(u64),
+    entries_dropped: std.atomic.Value(u64),
+    total_entries_written: std.atomic.Value(u64),
+    io_errors: std.atomic.Value(u64),
+
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub const Config = struct {
+        wal_path: []const u8,
+        max_threads: u32,
+        ring_buffer_size: u32,
+        batch_buffer_count: u32,
+        io_uring_entries: u16, // Size of io_uring submission queue
+    };
+
+    pub fn init(allocator: std.mem.Allocator, config: Config) !Self {
+        // Open WAL file with O_DIRECT for bypass page cache
+        const wal_fd = try std.posix.openat(
+            std.posix.AT.FDCWD,
+            config.wal_path,
+            .{ .ACCMODE = .RDWR, .CREAT = true, .DIRECT = true },
+            0o644,
+        );
+
+        // Initialize io_uring
+        const ring = try std.os.linux.IoUring.init(config.io_uring_entries, 0);
+
+        // Pre-allocate thread-local WAL rings
+        const tls_wals = try allocator.alloc(ThreadLocalWAL, config.max_threads);
+        for (tls_wals) |*tls_wal| {
+            tls_wal.* = try ThreadLocalWAL.init(allocator, config.ring_buffer_size);
+        }
+
+        // Pre-allocate batch buffers for durability thread
+        const batch_buffer_count = @min(32, config.batch_buffer_count); // Max 32 for bitmask
+        const actual_buffer_count = if (std.math.isPowerOfTwo(batch_buffer_count))
+            batch_buffer_count
+        else
+            std.math.floorPowerOfTwo(u32, batch_buffer_count);
+
+        const batch_buffers = try allocator.alignedAlloc(WALBatch, 512, actual_buffer_count);
+        const completions = try allocator.alloc(WALCompletion, actual_buffer_count);
+
+        // Initialize all batch buffers and completions
+        for (batch_buffers, 0..) |*batch, i| {
+            batch.* = WALBatch.init(@intCast(i), 0);
+        }
+
+        for (completions, 0..) |*completion, i| {
+            completion.* = WALCompletion.init(&batch_buffers[i], .write_batch);
+        }
+
+        // All buffers and completions start as available
+        const all_available = (@as(u32, 1) << @intCast(actual_buffer_count)) - 1;
+
+        return Self{
+            .wal_fd = wal_fd,
+            .wal_offset = std.atomic.Value(u64).init(0),
+            .ring = ring,
+            .tls_wals = tls_wals,
+            .current_tls_index = std.atomic.Value(u32).init(0),
+            .batch_buffers = batch_buffers,
+            .batch_buffer_available = std.atomic.Value(u32).init(all_available),
+            .completions = completions,
+            .completion_available = std.atomic.Value(u32).init(all_available),
+            .unqueued = null,
+            .completed = null,
+            .awaiting = null,
+            .unqueued_lock = std.Thread.Mutex{},
+            .completed_lock = std.Thread.Mutex{},
+            .awaiting_lock = std.Thread.Mutex{},
+            .pending_ios = std.atomic.Value(u32).init(0),
+            .completed_ios = std.atomic.Value(u64).init(0),
+            .durability_thread = null,
+            .should_stop = std.atomic.Value(bool).init(false),
+            .batches_written = std.atomic.Value(u64).init(0),
+            .entries_dropped = std.atomic.Value(u64).init(0),
+            .total_entries_written = std.atomic.Value(u64).init(0),
+            .io_errors = std.atomic.Value(u64).init(0),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        // Stop durability thread if running
+        if (self.durability_thread) |thread| {
+            self.should_stop.store(true, .release);
+            thread.join();
+        }
+
+        // Clean up io_uring
+        self.ring.deinit();
+
+        // Close WAL file
+        std.posix.close(self.wal_fd);
+
+        // Free thread-local WAL rings
+        for (self.tls_wals) |*tls_wal| {
+            tls_wal.deinit(self.allocator);
+        }
+        self.allocator.free(self.tls_wals);
+
+        // Free batch buffers and completions
+        self.allocator.free(self.batch_buffers);
+        self.allocator.free(self.completions);
+    }
+
+    pub fn start(self: *Self) !void {
+        std.debug.assert(self.durability_thread == null);
+        self.durability_thread = try std.Thread.spawn(.{}, durabilityLoop, .{self});
+    }
+
+    pub fn stop(self: *Self) void {
+        if (self.durability_thread) |thread| {
+            self.should_stop.store(true, .release);
+            thread.join();
+            self.durability_thread = null;
+        }
+    }
+
+    // Get a thread-local WAL ring - round-robin assignment
+    pub fn getThreadLocalWAL(self: *Self) *ThreadLocalWAL {
+        const index = self.current_tls_index.fetchAdd(1, .monotonic) % self.tls_wals.len;
+        return &self.tls_wals[index];
+    }
+
+    // Append WAL entry - never blocks, returns false if ring buffer full
+    pub fn appendAsync(self: *Self, record: *const flat_hash_storage.CacheLineRecord) bool {
+        const wal_entry = WALEntry.fromCacheLineRecord(record);
+
+        // Try multiple thread-local rings to improve success rate
+        var attempts: u8 = 0;
+        const max_attempts = @min(4, self.tls_wals.len);
+
+        while (attempts < max_attempts) {
+            const tls_wal = self.getThreadLocalWAL();
+
+            if (tls_wal.appendNonBlocking(wal_entry)) {
+                return true; // Success
+            }
+
+            attempts += 1;
+        }
+
+        // All attempts failed - record dropped entry
+        _ = self.entries_dropped.fetchAdd(1, .monotonic);
+        return false;
+    }
+
+    // Completion-based buffer management following TigerBeetle patterns
+    fn getAvailableCompletion(self: *Self) ?*WALCompletion {
+        const available = self.completion_available.load(.acquire);
+        if (available == 0) return null;
+
+        // Find first available completion using bit scan
+        const index = @ctz(available);
+        if (index >= self.completions.len) return null;
+
+        // Try to atomically claim this completion
+        const mask = @as(u32, 1) << @intCast(index);
+        const old_available = self.completion_available.fetchAnd(~mask, .acquire);
+
+        if ((old_available & mask) == 0) {
+            // Someone else claimed it, try again
+            return self.getAvailableCompletion();
+        }
+
+        const completion = &self.completions[index];
+        // Reset completion for reuse
+        completion.next = null;
+        completion.result = 0;
+        completion.batch.entry_count = 0;
+
+        return completion;
+    }
+
+    fn returnCompletion(self: *Self, completion: *WALCompletion) void {
+        // Find the index of this completion
+        const completion_ptr = @intFromPtr(completion);
+        const base_ptr = @intFromPtr(self.completions.ptr);
+        const index = (completion_ptr - base_ptr) / @sizeOf(WALCompletion);
+
+        if (index < self.completions.len) {
+            const mask = @as(u32, 1) << @intCast(index);
+            _ = self.completion_available.fetchOr(mask, .release);
+        }
+    }
+
+    // Queue management following TigerBeetles patterns
+    fn enqueueCompletion(self: *Self, head: *?*WALCompletion, completion: *WALCompletion, lock: *std.Thread.Mutex) void {
+        _ = self;
+        lock.lock();
+        defer lock.unlock();
+
+        completion.next = head.*;
+        head.* = completion;
+    }
+
+    fn dequeueCompletion(self: *Self, head: *?*WALCompletion, lock: *std.Thread.Mutex) ?*WALCompletion {
+        _ = self;
+        lock.lock();
+        defer lock.unlock();
+
+        const completion = head.* orelse return null;
+        head.* = completion.next;
+        completion.next = null;
+        return completion;
+    }
+
+    // io_uring-optimized durability thread main loop
+    fn durabilityLoop(self: *Self) void {
+        while (!self.should_stop.load(.acquire)) {
+            var submitted_count: u32 = 0;
+
+            // Phase 1: Collect and submit batches via io_uring
+            for (self.tls_wals) |*tls_wal| {
+                const completion = self.getAvailableCompletion() orelse break;
+                const batch = completion.batch;
+
+                const entry_count = tls_wal.drainBatch(batch);
+                if (entry_count > 0) {
+                    batch.batch_id = self.batches_written.fetchAdd(1, .monotonic);
+
+                    // Submit batch via io_uring (non-blocking)
+                    self.submitBatchAsync(completion) catch |err| {
+                        std.debug.print("WAL submit error: {}\n", .{err});
+                        _ = self.io_errors.fetchAdd(1, .monotonic);
+                        self.returnCompletion(completion);
+                        continue;
+                    };
+
+                    _ = self.total_entries_written.fetchAdd(entry_count, .monotonic);
+                    submitted_count += 1;
+                    // Note: completion will be processed when I/O completes
+                } else {
+                    self.returnCompletion(completion);
+                }
+            }
+
+            // Phase 2: Process completions if we have pending I/Os
+            const pending = self.pending_ios.load(.acquire);
+            if (pending > 0 or submitted_count > 0) {
+                // Submit all queued operations with retry logic
+                if (submitted_count > 0) {
+                    var submit_attempts: u8 = 0;
+                    while (submit_attempts < 3) {
+                        _ = self.ring.submit() catch |err| switch (err) {
+                            error.SystemResources => {
+                                submit_attempts += 1;
+                                std.time.sleep(@as(u64, 1000) * submit_attempts); // Exponential backoff
+                                continue;
+                            },
+                            error.CompletionQueueOvercommitted => {
+                                submit_attempts += 1;
+                                std.time.sleep(@as(u64, 1000) * submit_attempts); // Exponential backoff
+                                continue;
+                            },
+                            else => {
+                                std.debug.print("io_uring submit error: {}\n", .{err});
+                                break;
+                            },
+                        };
+                        break; // Success
+                    }
+                }
+
+                // Wait for at least one completion (with retry)
+                var completion_attempts: u8 = 0;
+                while (completion_attempts < 3) {
+                    self.processCompletions() catch |err| {
+                        completion_attempts += 1;
+                        std.debug.print("Completion processing error: {} (attempt {})\n", .{ err, completion_attempts });
+                        if (completion_attempts >= 3) break;
+                        std.time.sleep(@as(u64, 1000) * completion_attempts);
+                        continue;
+                    };
+                    break; // Success
+                }
+            } else {
+                // No work - sleep briefly
+                std.time.sleep(1000); // 1μs
+            }
+        }
+
+        // Final cleanup: wait for all pending I/Os to complete with robust retry
+        var cleanup_attempts: u32 = 0;
+        while (self.pending_ios.load(.acquire) > 0 and cleanup_attempts < 100) {
+            // Submit any remaining operations
+            _ = self.ring.submit() catch {};
+
+            // Process completions with progressively longer waits
+            self.processCompletions() catch |err| {
+                std.debug.print("Cleanup completion error: {}\n", .{err});
+            };
+
+            cleanup_attempts += 1;
+            if (cleanup_attempts > 20) {
+                // After 20 attempts, start backing off more aggressively
+                const backoff_ms = @min(cleanup_attempts - 20, 10);
+                std.time.sleep(@as(u64, backoff_ms) * 1000_000); // Convert to nanoseconds
+            } else {
+                std.time.sleep(1000); // 1μs between early attempts
+            }
+        }
+
+        // Final flush attempt
+        if (self.pending_ios.load(.acquire) > 0) {
+            std.debug.print("Final flush attempt for {} pending I/Os...\n", .{self.pending_ios.load(.acquire)});
+            _ = self.ring.submit() catch {};
+
+            // One more completion attempt
+            self.processCompletions() catch {};
+
+            // Report remaining pending operations
+            const final_pending = self.pending_ios.load(.acquire);
+            if (final_pending > 0) {
+                std.debug.print("Warning: {} pending I/Os could not be completed during shutdown\n", .{final_pending});
+            }
+        }
+    }
+
+    // Submit batch to io_uring for async write (non-blocking)
+    fn submitBatchAsync(self: *Self, completion: *WALCompletion) !void {
+        const batch = completion.batch;
+        if (batch.isEmpty()) return;
+
+        // Get submission queue entry with retry logic
+        const sqe = blk: {
+            // First attempt
+            if (self.ring.get_sqe()) |sqe_ptr| {
+                break :blk sqe_ptr;
+            } else |err| switch (err) {
+                error.SubmissionQueueFull => {
+                    // SQ full - flush pending operations first
+                    _ = self.ring.submit() catch {};
+                    // Try again after flush
+                    break :blk try self.ring.get_sqe();
+                },
+                else => return err,
+            }
+        };
+
+        // Calculate file offset for this batch
+        const offset = self.wal_offset.fetchAdd(@sizeOf(WALBatch), .monotonic);
+
+        // Prepare write operation
+        sqe.prep_write(
+            self.wal_fd,
+            std.mem.asBytes(batch),
+            offset,
+        );
+
+        // Set user data to identify the completion on completion
+        sqe.user_data = @intFromPtr(completion);
+
+        // Add to awaiting queue and track pending I/O
+        self.enqueueCompletion(&self.awaiting, completion, &self.awaiting_lock);
+        _ = self.pending_ios.fetchAdd(1, .monotonic);
+    }
+
+    // Process io_uring completions following TigerBeetle patterns
+    fn processCompletions(self: *Self) !void {
+        // Wait for at least one completion with short timeout
+        const completed = self.ring.submit_and_wait(1) catch |err| switch (err) {
+            error.SystemResources => {
+                // io_uring overcommitted - wait and retry
+                std.time.sleep(1000); // 1μs
+                return;
+            },
+            error.CompletionQueueOvercommitted => {
+                // CQ overcommitted - wait and retry
+                std.time.sleep(1000); // 1μs
+                return;
+            },
+            else => return err,
+        };
+
+        if (completed == 0) return; // Timeout, no completions
+
+        // Process all available completions
+        var cqe_count: u32 = 0;
+        while (self.ring.cq_ready() > 0) {
+            const cqe = try self.ring.copy_cqe();
+
+            // Recover completion pointer from user_data
+            const completion = @as(*WALCompletion, @ptrFromInt(cqe.user_data));
+            completion.result = cqe.res;
+
+            // Move from awaiting to completed queue
+            // Note: In a more complex system, we'd search awaiting queue
+            // For now, we trust the completion came from awaiting
+            self.enqueueCompletion(&self.completed, completion, &self.completed_lock);
+
+            if (cqe.res < 0) {
+                // I/O error
+                std.debug.print("WAL write error: {}\n", .{cqe.res});
+                _ = self.io_errors.fetchAdd(1, .monotonic);
+            } else if (cqe.res != @sizeOf(WALBatch)) {
+                // Incomplete write
+                std.debug.print("WAL incomplete write: {} bytes\n", .{cqe.res});
+                _ = self.io_errors.fetchAdd(1, .monotonic);
+            }
+
+            // Update counters
+            _ = self.pending_ios.fetchSub(1, .monotonic);
+            _ = self.completed_ios.fetchAdd(1, .monotonic);
+            cqe_count += 1;
+        }
+
+        // Process completed queue - return completions to pool
+        while (self.dequeueCompletion(&self.completed, &self.completed_lock)) |completion| {
+            // Log successful writes if needed
+            if (completion.result == @sizeOf(WALBatch)) {
+                // Success - batch was written
+            }
+
+            // Return completion to available pool
+            self.returnCompletion(completion);
+        }
+    }
+
+    // Statistics for monitoring
+    pub const RingUsage = struct { used: u32, capacity: u32 };
+
+    pub const Stats = struct {
+        batches_written: u64,
+        entries_dropped: u64,
+        total_entries_written: u64,
+        wal_size_bytes: u64,
+        pending_ios: u32,
+        completed_ios: u64,
+        io_errors: u64,
+        ring_buffer_usage: []RingUsage,
+    };
+
+    pub fn getStats(self: *const Self, allocator: std.mem.Allocator) !Stats {
+        var ring_usage = try allocator.alloc(RingUsage, self.tls_wals.len);
+
+        for (self.tls_wals, 0..) |*tls_wal, i| {
+            const usage = tls_wal.getUsage();
+            ring_usage[i] = RingUsage{ .used = usage.used, .capacity = usage.capacity };
+        }
+
+        return Stats{
+            .batches_written = self.batches_written.load(.monotonic),
+            .entries_dropped = self.entries_dropped.load(.monotonic),
+            .total_entries_written = self.total_entries_written.load(.monotonic),
+            .wal_size_bytes = self.wal_offset.load(.monotonic),
+            .pending_ios = self.pending_ios.load(.monotonic),
+            .completed_ios = self.completed_ios.load(.monotonic),
+            .io_errors = self.io_errors.load(.monotonic),
+            .ring_buffer_usage = ring_usage,
+        };
+    }
+
+    // Get stats without allocating - for use after static allocator is frozen
+    pub fn getStatsNoAlloc(self: *const Self) struct {
+        batches_written: u64,
+        entries_dropped: u64,
+        total_entries_written: u64,
+        wal_size_bytes: u64,
+        pending_ios: u32,
+        completed_ios: u64,
+        io_errors: u64,
+    } {
+        return .{
+            .batches_written = self.batches_written.load(.monotonic),
+            .entries_dropped = self.entries_dropped.load(.monotonic),
+            .total_entries_written = self.total_entries_written.load(.monotonic),
+            .wal_size_bytes = self.wal_offset.load(.monotonic),
+            .pending_ios = self.pending_ios.load(.monotonic),
+            .completed_ios = self.completed_ios.load(.monotonic),
+            .io_errors = self.io_errors.load(.monotonic),
+        };
+    }
+};

--- a/src/wal.zig
+++ b/src/wal.zig
@@ -165,7 +165,6 @@ pub const ThreadLocalWAL = struct {
     }
 };
 
-// WAL completion following TigerBeetle patterns
 pub const WALCompletion = struct {
     next: ?*WALCompletion,
     batch: *WALBatch,
@@ -207,7 +206,7 @@ pub const DurabilityManager = struct {
     completions: []WALCompletion,
     completion_available: std.atomic.Value(u32), // Bitmask for available completions
 
-    // Completion queues following TigerBeetle pattern
+    // Completion queues
     unqueued: ?*WALCompletion,
     completed: ?*WALCompletion,
     awaiting: ?*WALCompletion,
@@ -377,7 +376,6 @@ pub const DurabilityManager = struct {
         return false;
     }
 
-    // Completion-based buffer management following TigerBeetle patterns
     fn getAvailableCompletion(self: *Self) ?*WALCompletion {
         const available = self.completion_available.load(.acquire);
         if (available == 0) return null;
@@ -416,7 +414,6 @@ pub const DurabilityManager = struct {
         }
     }
 
-    // Queue management following TigerBeetles patterns
     fn enqueueCompletion(self: *Self, head: *?*WALCompletion, completion: *WALCompletion, lock: *std.Thread.Mutex) void {
         _ = self;
         lock.lock();
@@ -677,7 +674,6 @@ pub const DurabilityManager = struct {
         _ = self.pending_ios.fetchAdd(1, .monotonic);
     }
 
-    // Process io_uring completions following TigerBeetle patterns
     fn processCompletions(self: *Self) !void {
         // First try to get existing completions without waiting
         if (self.ring.cq_ready() > 0) {


### PR DESCRIPTION
Uses io_uring on Linux, still only works on Linux.

Adds a write ahead log for durability. Cache lines are written to disk using io_uring, aysnc, and batched by cache line.
Adds a wal recovery stage on startup to recover the wall
Makes the WAL opt-in, if you don't want it, don't set it up
Adds a few benchmark files to test the implementation.

## Summary by Sourcery

Implement optional persistence for the WILD database by adding a WAL durability layer backed by io_uring and a snapshot mechanism, integrate crash recovery, and supply benchmarks to evaluate performance and recovery

New Features:
- Introduce optional write-ahead log (WAL) durability manager using Linux io_uring for async, batched cache-line writes
- Add optional snapshot manager with memory-mapped snapshot files and APIs to create, restore, and manage snapshots
- Provide crash recovery via a RecoveryCoordinator that loads the latest snapshot and replays the WAL
- Expose new WILD methods to enable/disable durability and snapshots, perform recovery, and retrieve durability statistics

Enhancements:
- Integrate durability and snapshot hooks into flat_hash_storage (async WAL append, atomic record copy, record restore)
- Swap metadata and key ordering in CacheLineRecord for consistent layout
- Extend WILD struct to hold optional durability and snapshot managers and clean them up on deinit

Tests:
- Add multiple benchmark programs (performance_benchmark.zig, recovery_benchmark.zig, quick_benchmark.zig) to measure core performance, WAL overhead, and recovery speed